### PR TITLE
add get_wallet_from_onchain_trade_info to ape_utils

### DIFF
--- a/elfpy/__init__.py
+++ b/elfpy/__init__.py
@@ -37,6 +37,9 @@ DEFAULT_LOG_FORMATTER = "\n%(asctime)s: %(levelname)s: %(module)s.%(funcName)s:\
 DEFAULT_LOG_DATETIME = "%y-%m-%d %H:%M:%S"
 DEFAULT_LOG_MAXBYTES = int(2e6)  # 2MB
 
+# Constant for time conversion
+SECONDS_IN_YEAR = 365 * 24 * 60 * 60  # 31_536_000
+
 # Plotting defaults
 WHITE = "white"
 LIGHTGREY = "#D3D3D3"

--- a/elfpy/__init__.py
+++ b/elfpy/__init__.py
@@ -40,6 +40,9 @@ DEFAULT_LOG_MAXBYTES = int(2e6)  # 2MB
 # Constant for time conversion
 SECONDS_IN_YEAR = 365 * 24 * 60 * 60  # 31_536_000
 
+# Maximum balance mismatch between trade-level aggregation and balanceOf query in apeworx integration
+MAXIMUM_BALANCE_MISMATCH_IN_WEI = 2
+
 # Plotting defaults
 WHITE = "white"
 LIGHTGREY = "#D3D3D3"

--- a/elfpy/utils/apeworx_integrations.py
+++ b/elfpy/utils/apeworx_integrations.py
@@ -17,11 +17,13 @@ from ape.contracts.base import ContractTransaction, ContractTransactionHandler
 import numpy as np
 import pandas as pd
 
+import elfpy
+from elfpy import types
 from elfpy.types import freezable
-
 from elfpy.markets.hyperdrive import hyperdrive_assets, hyperdrive_market
 from elfpy.utils.outputs import number_to_string as fmt
 from elfpy.utils.outputs import log_and_show
+from elfpy.agents.wallet import Long, Short, Wallet
 from elfpy.math import FixedPoint
 
 if TYPE_CHECKING:
@@ -29,6 +31,28 @@ if TYPE_CHECKING:
     from ape.contracts.base import ContractInstance
     from ape.types import ContractLog
     from ethpm_types.abi import MethodABI
+
+
+class HyperdriveProject(ProjectManager):
+    """Hyperdrive project class, to provide static typing for the Hyperdrive contract."""
+
+    hyperdrive: ContractContainer
+    address: str = "0xB311B825171AF5A60d69aAD590B857B1E5ed23a2"
+
+    def __init__(self, path: Path) -> None:
+        """Initialize the project, loading the Hyperdrive contract."""
+        if path.name == "examples":  # if in examples folder, move up a level
+            path = path.parent
+        super().__init__(path)
+        self.load_contracts()
+        try:
+            self.hyperdrive: ContractContainer = self.get_contract("Hyperdrive")
+        except AttributeError as err:
+            raise AttributeError("Hyperdrive contract not found") from err
+
+    def get_hyperdrive_contract(self) -> ContractInstance:
+        """Get the Hyperdrive contract instance."""
+        return self.hyperdrive.at(self.conversion_manager.convert(self.address, AddressType))
 
 
 def get_market_state_from_contract(contract: ContractInstance, **kwargs) -> hyperdrive_market.MarketState:
@@ -82,7 +106,7 @@ def get_market_state_from_contract(contract: ContractInstance, **kwargs) -> hype
 
 
 OnChainTradeInfo = namedtuple(
-    "OnChainTradeInfo", ["hyper_trades", "unique_maturities", "unique_ids", "unique_block_numbers", "share_price"]
+    "OnChainTradeInfo", ["trades", "unique_maturities", "unique_ids", "unique_block_numbers", "share_price"]
 )
 
 
@@ -98,7 +122,7 @@ def get_on_chain_trade_info(hyperdrive: ContractInstance) -> OnChainTradeInfo:
     -------
     OnChainTradeInfo
         Named tuple containing the following fields:
-        - hyper_trades: pd.DataFrame
+        - trades: pd.DataFrame
             DataFrame containing all trades from the Hyperdrive contract.
         - unique_maturities: list
             List of unique maturity timestamps across all assets.
@@ -109,28 +133,26 @@ def get_on_chain_trade_info(hyperdrive: ContractInstance) -> OnChainTradeInfo:
         - share_price_
             Map of share price to block number.
     """
-    # get all trades and process
-    hyper_trades_ = hyperdrive.TransferSingle.query("*")
-    hyper_trades_ = pd.concat(
+    trades = hyperdrive.TransferSingle.query("*")  # get all trades
+    trades = pd.concat(  # flatten event_arguments
         [
-            # hyper_trades_.loc[:, ["block_number", "event_name"]], # keep only block_number and event_name
-            hyper_trades_.loc[:, [c for c in hyper_trades_.columns if c != "event_arguments"]],  # keep everything
-            pd.DataFrame((dict(i) for i in hyper_trades_["event_arguments"])),
+            trades.loc[:, [c for c in trades.columns if c != "event_arguments"]],
+            pd.DataFrame((dict(i) for i in trades["event_arguments"])),
         ],
         axis=1,
     )
-    tuple_series = hyper_trades_.apply(func=lambda x: hyperdrive_assets.decode_asset_id(int(x["id"])), axis=1)
-    hyper_trades_["prefix"], hyper_trades_["maturity_timestamp"] = zip(*tuple_series)  # split into two columns
-    hyper_trades_["trade_type"] = hyper_trades_["prefix"].apply(lambda x: hyperdrive_assets.AssetIdPrefix(x).name)
-    hyper_trades_["value"] = hyper_trades_["value"]
+    tuple_series = trades.apply(func=lambda x: hyperdrive_assets.decode_asset_id(int(x["id"])), axis=1)
+    trades["prefix"], trades["maturity_timestamp"] = zip(*tuple_series)  # split into two columns
+    trades["trade_type"] = trades["prefix"].apply(lambda x: hyperdrive_assets.AssetIdPrefix(x).name)
+    trades["value"] = trades["value"]
 
-    unique_maturities_ = hyper_trades_["maturity_timestamp"].unique()
+    unique_maturities_ = trades["maturity_timestamp"].unique()
     unique_maturities_ = unique_maturities_[unique_maturities_ != 0]
 
-    unique_ids_: np.ndarray = hyper_trades_["id"].unique()
+    unique_ids_: np.ndarray = trades["id"].unique()
     unique_ids_ = unique_ids_[unique_ids_ != 0]
 
-    unique_block_numbers_ = hyper_trades_["block_number"].unique()
+    unique_block_numbers_ = trades["block_number"].unique()
 
     # map share price to block number
     share_price_ = {}
@@ -139,7 +161,80 @@ def get_on_chain_trade_info(hyperdrive: ContractInstance) -> OnChainTradeInfo:
     for block_number_, price in share_price_.items():
         logging.debug(("block_number_={}, price={}", block_number_, price))
 
-    return OnChainTradeInfo(hyper_trades_, unique_maturities_, unique_ids_, unique_block_numbers_, share_price_)
+    return OnChainTradeInfo(trades, unique_maturities_, unique_ids_, unique_block_numbers_, share_price_)
+
+
+def log_subtotals(balance, query_balance, hyper_trades, idx, asset_type):
+    """Validate balance between the record of trades and the balanceOf query."""
+    if balance != query_balance:  # check that our calculated total matches the aggregate stored on-chain
+        running_total = 0
+        for i in hyper_trades.loc[idx, :].itertuples():  # show how each trades adds up to the total
+            running_total += i.value
+            log_and_show(f"  {asset_type} {i.value=} => {running_total=}")
+        log_and_show(
+            f" SUBTOTAL {running_total=} is off {query_balance} by {(balance - query_balance):.1E}"
+            f"({(balance - query_balance)*1e18} wei))"
+        )
+
+
+def get_wallet_from_onchain_trade_info(
+    address_: str, index: int, info: OnChainTradeInfo, hyperdrive: ContractInstance, base: ContractInstance
+):
+    """Construct wallet balances from on-chain trade info.
+
+    Parameters
+    ----------
+    address_: str
+        Address of the wallet.
+    index: int
+        Index of the wallet.
+    on_chain_trade_info: OnChainTradeInfo
+        On-chain trade info.
+
+    Returns
+    -------
+    Wallet
+        Wallet with Short, Long, and LP positions.
+    """
+
+    shorts: dict[float, Short] = defaultdict(lambda: Short(0, 0))
+    longs: dict[float, Long] = defaultdict(lambda: Long(0))
+    lp_tokens = 0
+    for id_ in info.unique_ids:  # loop across all the positions
+        idx = (info.trades["operator"] == address_) & (info.trades["id"] == id_)
+        balance = info.trades.loc[idx, "value"].sum()
+        asset_prefix, maturity = hyperdrive_assets.decode_asset_id(id_)
+        asset_type = hyperdrive_assets.AssetIdPrefix(asset_prefix).name
+        assert (
+            abs(balance - hyperdrive.balanceOf(id_, address_)) < 3
+        ), f"events {balance=} != {hyperdrive.balanceOf(id_, address_)=} for address {address_}"
+        if balance != 0 or hyperdrive.balanceOf(id_, address_) != 0:  # this agent has a position in this asset
+            logging.debug(
+                "%s %s maturing %s, balance: from events %s, from balanceOf %s",
+                address_[:8],
+                asset_type,
+                maturity,
+                balance,
+                hyperdrive.balanceOf(id_, address_),
+            )
+            log_subtotals(balance, hyperdrive.balanceOf(id_, address_), info.trades, idx, asset_type)
+            for idx in idx.index[idx]:  # loop across all the positions owned by this wallet
+                if asset_type == "SHORT":
+                    open_share_price = info.share_price[info.trades.loc[idx, "block_number"]]
+                    shorts |= {
+                        maturity - elfpy.SECONDS_IN_YEAR: Short(balance=balance, open_share_price=open_share_price)
+                    }
+                elif asset_type == "LONG":
+                    longs |= {maturity - elfpy.SECONDS_IN_YEAR: Long(balance=balance)}
+                elif asset_type == "LP":
+                    lp_tokens += balance
+    return Wallet(
+        address=index,  # TODO: remove restriction forcing Wallet index to be an int (issue #415)
+        balance=types.Quantity(amount=base.balanceOf(address_), unit=types.TokenType.BASE),
+        shorts=shorts,
+        longs=longs,
+        lp_tokens=lp_tokens,
+    )
 
 
 def get_gas_fees(block: BlockAPI) -> tuple[list[float], list[float]]:


### PR DESCRIPTION
I loop across all the positions as captured by the `unique_ids` in the `OnChainTradeInfo` input.
For each position:
- calculate the balance across all trades for that position, and compare it to a `balanceOf` query.
- if there's an outstanding balance, create a wallet entry for each trade that comprises it

fixes: #419 