### PR TITLE
remove deepcopy from fixedpoint

### DIFF
--- a/elfpy/math/fixed_point.py
+++ b/elfpy/math/fixed_point.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import re
-import copy
 from typing import Union, Any, Literal
 
 import elfpy.errors.errors as errors
@@ -592,9 +591,9 @@ class FixedPoint:
         r"""Returns a hash of self"""
         # act like a float for non-finite
         if not self.is_finite():
-            return hash((float(copy.deepcopy(self)), self.__class__.__name__))
+            return hash((float(self), self.__class__.__name__))
         # act like an integer otherwise
-        return hash((copy.deepcopy(self).scaled_value, self.__class__.__name__))
+        return hash((self.scaled_value, self.__class__.__name__))
 
     # additional arethmitic & helper functions
     def div_up(self, other: OtherTypes | FixedPoint) -> FixedPoint:

--- a/examples/hyperdrive_demo_notebook.py
+++ b/examples/hyperdrive_demo_notebook.py
@@ -237,7 +237,9 @@ long_agents = get_example_agents(
 simulator.add_agents(short_agents + long_agents)
 print(f"Simulator has {len(simulator.agents)} agents")
 
+# %%
 # run the simulation
+
 simulator.run_simulation()
 
 # %%


### PR DESCRIPTION
It appears as though a recent update has increased the execution time of the hyperdrive demo, and thus our CI tests.

Using the [Python Profiler](https://docs.python.org/3/library/profile.html) we can get an idea of where the slowdown is coming from. I created a temp python file that strips the unnecessary components from `examples/hyperdrive_demo_notebook.py` and only includes the lines up to `simulator.run_simulation()`. Then I used the profiler to see what is taking so long:

in a terminal:
`python -m cProfile -o elf-profile temp.py`

then in python interactive:
```
>>> import pstats
>>> from pstats import SortKey
>>> p = pstats.Stats('elf-profile')
>>> p.sort_stats(SortKey.CUMULATIVE).print_stats(10)
```

This returns:
```
Tue May 30 14:33:46 2023    elf-profile

         319872285 function calls (283970621 primitive calls) in 53.342 seconds

   Ordered by: cumulative time
   List reduced from 5138 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    720/1    0.006    0.000   53.550   53.550 {built-in method builtins.exec}
        1    0.000    0.000   53.550   53.550 temp.py:2(<module>)
        1    0.000    0.000   52.373   52.373 /Users/dylan/code/element/elf-simulations/elfpy/simulators/simulators.py:600(run_simulation)
        9    0.000    0.000   52.361    5.818 /Users/dylan/code/element/elf-simulations/elfpy/simulators/simulators.py:488(collect_and_execute_trades)
        9    0.003    0.000   52.328    5.814 /Users/dylan/code/element/elf-simulations/elfpy/simulators/simulators.py:548(execute_trades)
      270    0.018    0.000   50.735    0.188 /Users/dylan/code/element/elf-simulations/elfpy/simulators/simulators.py:685(update_simulation_state)
    27270    0.197    0.000   50.461    0.002 /Users/dylan/code/element/elf-simulations/elfpy/agents/get_wallet_state.py:9(get_wallet_state)
29878502/103251   13.687    0.000   30.068    0.000 /Users/dylan/.pyenv/versions/3.9.16/lib/python3.9/copy.py:128(deepcopy)
    16762    0.099    0.000   29.580    0.002 /Users/dylan/code/element/elf-simulations/elfpy/markets/hyperdrive/hyperdrive_market.py:171(copy)
2701351/103251    3.023    0.000   29.461    0.000 /Users/dylan/.pyenv/versions/3.9.16/lib/python3.9/copy.py:226(_deepcopy_dict)


<pstats.Stats object at 0x102ba0f70>
```

So it seems like a lot of the time is sucked up by calling `copy` and `deepcopy`.  We use `deepcopy` in `hyperdrive_market.py::MarketState.copy()` [link](https://github.com/delvtech/elf-simulations/blob/9b7c228b00a604f8abc4310d0fc7c9915d4902c7/elfpy/markets/hyperdrive/hyperdrive_market.py#L171):
```
    def copy(self) -> MarketState:
        """Returns a new copy of self"""
        return MarketState(**copy.deepcopy(self.__dict__))
```
and in `wallet.py::Wallet.copy()` [link](https://github.com/delvtech/elf-simulations/blob/9b7c228b00a604f8abc4310d0fc7c9915d4902c7/elfpy/agents/wallet.py#L125):
```
    def copy(self) -> Wallet:
        """Returns a new copy of self"""
        return Wallet(**copy.deepcopy(self.__dict__))
```

These functions are called a few times:

```
(.venv) dylan@Dylans-MacBook-Pro elf-simulations % grep -rs ".copy()" elfpy/
elfpy//pricing_models/hyperdrive.py:        market_state = market_state.copy()
elfpy//pricing_models/hyperdrive.py:        market_state = market_state.copy()  # don't want to modify the actual market state
elfpy//simulators/simulators.py:        self.config = config.copy()
elfpy//simulators/simulators.py:            market_state_before_trade = self.market.market_state.copy()
elfpy//agents/wallet.py:        for key, value_or_dict in wallet_deltas.copy().__dict__.items():
```

Notably, the market state gets copied a _minimum_ of 3 times _per trade_: once before the trade in `simulators.py`, once during the trade in `pricing_models/hyperdrive.py` and then once after the trade in `get_wallet_state` (which also calls the pricing model function). That number gets much worse as the simulation progresses, since the number of calls inside `get_wallet_state` equals the total number of open longs and shorts.

Looking around, I found one other place where we use `deepcopy`:
```
(.venv) dylan@Dylans-MacBook-Pro elf-simulations % grep -rs "deepcopy" elfpy/
elfpy//agents/wallet.py:        return Wallet(**copy.deepcopy(self.__dict__))
elfpy//math/fixed_point.py:            return hash((float(copy.deepcopy(self)), self.__class__.__name__))
elfpy//math/fixed_point.py:        return hash((copy.deepcopy(self).scaled_value, self.__class__.__name__))
elfpy//markets/hyperdrive/hyperdrive_market.py:        return MarketState(**copy.deepcopy(self.__dict__))
```

The usage in `fixed_point.py` is unnecessary and was added before we made the class immutable. I removed this in the first commit to this PR. The other ones seem necessary, though.

We have two tests that explicitly test copying. They both fail if we ditch the `copy.deepcopy` or even change it to `copy.copy` (which uses refs wherever possible). There are a number of other tests that are implicitly expecting this to work that fail as well.

test_agents.py::
```
    def test_wallet_copy(self):
        """Test the wallet ability to deep copy itself"""
        example_wallet = wallet.Wallet(
            address=0, balance=types.Quantity(amount=FixedPoint("100.0"), unit=types.TokenType.BASE)
        )
        wallet_copy = example_wallet.copy()
        assert example_wallet is not wallet_copy  # not the same object
        assert example_wallet == wallet_copy  # they have the same attribute values
        wallet_copy.address += 1
        assert example_wallet != wallet_copy  # now they should have different attribute values
```

test_market.py::
```
    def test_market_state_copy(self):
        """Test the market state ability to deep copy itself"""
        market_state = hyperdrive_market.MarketState()
        market_state_copy = market_state.copy()
        assert market_state is not market_state_copy  # not the same object
        assert market_state == market_state_copy  # they have the same attribute values
        market_state_copy.share_reserves += FixedPoint("10.0")
        assert market_state != market_state_copy  # now they should have different attribute values
```

Unfortunately, however, from what I can tell removing these copies does not dramatically decrease the run-time for `tests/test_examples.py`, which includes the hyperdrive example. This is the timing for removing **all three** `deepcopy` calls from the code:

without changes:
trial 1: ```PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest --tb=short tests/test_examples.py 69.28s user 3.44s system 103% cpu 1:09.97 total```
trial 2:  ```PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest --tb=short tests/test_examples.py 62.83s user 2.24s system 109% cpu 59.620 total```

with changes:
trial 1: ```PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest --tb=short tests/test_examples.py 61.75s user 2.61s system 108% cpu 59.268 total```

trial 2: ```PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest --tb=short tests/test_examples.py 60.94s user 2.76s system 110% cpu 57.867 total```


My conclusion is that we still need to investigate this further to figure out what is causing the slowdown.