### PR TITLE
don't lint .venv in hyperdrive

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -48,7 +48,7 @@ ignore=CVS
 # ignore-list. The regex matches against paths and can be in Posix or Windows
 # format. Because '\' represents the directory delimiter on Windows systems, it
 # can't be used as an escape character.
-ignore-paths=docs,.venv
+ignore-paths=docs,.venv,hyperdrive_solidity/.venv
 
 # Files or directories matching the regular expression patterns are skipped.
 # The regex matches against base names, not paths. The default value ignores

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ line-length = "120"
 extend-exclude = "\\.ipynb"
 
 [tool.pyright]
-<<<<<<< Updated upstream
 exclude = ["hyperdrive_solidity", "docs", ".venv"]
 
 [tool.ruff]
@@ -60,8 +59,6 @@ ignore = ["D203", "D213", "D416"]
 fixable = ["A", "D", "I", "N", "PL"]
 unfixable = []
 
-exclude = ["hyperdrive_solidity", "docs", ".venv"]
-
 # override pow in fixed_point, and allow literal comparison in tests
 per-file-ignores = { "elfpy/utils/math/fixed_point.py" = [
     "A003",
@@ -77,10 +74,8 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 # Assume Python 3.9.
 target-version = "py39"
-=======
 exclude = [
-    "hyperdrive_solidity",
-    "hyperdrive_solidity/.venv",
     ".venv",
+    "docs",
+    "hyperdrive_solidity/.venv",
 ]
->>>>>>> Stashed changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ line-length = "120"
 extend-exclude = "\\.ipynb"
 
 [tool.pyright]
+<<<<<<< Updated upstream
 exclude = ["hyperdrive_solidity", "docs", ".venv"]
 
 [tool.ruff]
@@ -76,3 +77,10 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 # Assume Python 3.9.
 target-version = "py39"
+=======
+exclude = [
+    "hyperdrive_solidity",
+    "hyperdrive_solidity/.venv",
+    ".venv",
+]
+>>>>>>> Stashed changes


### PR DESCRIPTION
This was bogging down VSCode.  Make sure that .venv inside the hyperdrive repo doesn't get linted etc.