### PR TITLE
Building notebooks in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,8 @@ elf-env
 docs/source/_autosummary
 docs/source/generated
 docs/source/autoapi
+docs/source/examples
 docs/build
-docs/notebook_build
 docs/make_outputs.log
 
 # mypy

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,9 @@ help:
 
 .PHONY: help Makefile
 
+notebook:
+	@../scripts/notebook_docs.sh
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+Elfpy documentation and notebook examples can be built locally using the provided Makefile. To build local documentations that include notebook examples in `examples/*_notebooks.py`, run from this directory
+
+```
+make notebook;
+make html
+```
+This executes and converts all the `jupytext` notebooks in `examples/*_notebooks.py` to html files and creates the documentation with links to the notebooks using Sphinx. Note that documentation built in CI does not include notebook examples.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,8 +20,14 @@ sys.path.insert(0, elfpy_root)
 
 # -- Auto notebook index creation --------------------------------------------
 
-files = os.listdir('examples/_static')
+static_indir = 'examples/_static'
 rst_outdir = 'examples/notebook/'
+
+if os.path.exists(static_indir):
+    files = os.listdir('examples/_static')
+else:
+    files = []
+
 if not os.path.exists(rst_outdir):
     os.makedirs(rst_outdir)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,47 @@ sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, elfpy_root)
 
 
+# -- Auto notebook index creation --------------------------------------------
+
+files = os.listdir('examples/_static')
+rst_outdir = 'examples/notebook/'
+if not os.path.exists(rst_outdir):
+    os.makedirs(rst_outdir)
+
+# Static page text, needs title at front and path at end
+middle_text = """
+=================================================
+
+.. raw:: html
+    :file: """
+
+# Create an rst file per notebook output
+for f in files:
+    raw_name = f.split('.')[0]
+    title_name = raw_name.replace('_', ' ').title()
+
+    with open (rst_outdir+raw_name+".rst", 'w', encoding='UTF-8') as file:
+        file.write(title_name + middle_text + "../_static/" + f + "\n")
+
+text = """Examples
+=================================================
+
+.. toctree::
+   :titlesonly:
+
+"""
+
+# Create outer index.rst for examples
+for f in files:
+    raw_name = f.split('.')[0]
+    text += "   /" + rst_outdir + raw_name + "\n"
+
+with open ("examples/index.rst", 'w', encoding='UTF-8') as file:
+    file.write(text)
+
+
+
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 def _get_project_meta():
@@ -120,3 +161,5 @@ html_title = f"{project} v{release} documentation"
 language = "en"
 today_fmt = "%B %d, %Y"
 todo_include_todos = False
+
+# 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,7 +77,7 @@ pkg_meta = _get_project_meta()
 project = str(pkg_meta["name"])
 author = ", ".join([person["name"] for person in pkg_meta["authors"]])
 organization = "Delv"
-copyright = f" {datetime.date.today().year}, {organization}"
+copyright = f" {datetime.date.today().year}, {organization}" # pylint: disable=redefined-builtin
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ for f in files:
     raw_name = f.split(".")[0]
     title_name = raw_name.replace("_", " ").title()
 
-    with open (rst_outdir+raw_name+".rst", "w", encoding="UTF-8") as file:
+    with open(rst_outdir+raw_name+".rst", "w", encoding="UTF-8") as file:
         file.write(title_name + middle_text + "../_static/" + f + "\n")
 
 text = """Examples
@@ -59,7 +59,7 @@ for f in files:
     raw_name = f.split(".")[0]
     text += "   /" + rst_outdir + raw_name + "\n"
 
-with open ("examples/index.rst", "w", encoding="UTF-8") as file:
+with open("examples/index.rst", "w", encoding="UTF-8") as file:
     file.write(text)
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -167,5 +167,3 @@ html_title = f"{project} v{release} documentation"
 language = "en"
 today_fmt = "%B %d, %Y"
 todo_include_todos = False
-
-# 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ for f in files:
     raw_name = f.split(".")[0]
     title_name = raw_name.replace("_", " ").title()
 
-    with open(rst_outdir+raw_name+".rst", "w", encoding="UTF-8") as file:
+    with open(rst_outdir + raw_name + ".rst", "w", encoding="UTF-8") as file:
         file.write(title_name + middle_text + "../_static/" + f + "\n")
 
 text = """Examples

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,11 +20,11 @@ sys.path.insert(0, elfpy_root)
 
 # -- Auto notebook index creation --------------------------------------------
 
-static_indir = 'examples/_static'
-rst_outdir = 'examples/notebook/'
+static_indir = "examples/_static"
+rst_outdir = "examples/notebook/"
 
 if os.path.exists(static_indir):
-    files = os.listdir('examples/_static')
+    files = os.listdir("examples/_static")
 else:
     files = []
 
@@ -40,10 +40,10 @@ middle_text = """
 
 # Create an rst file per notebook output
 for f in files:
-    raw_name = f.split('.')[0]
-    title_name = raw_name.replace('_', ' ').title()
+    raw_name = f.split(".")[0]
+    title_name = raw_name.replace("_", " ").title()
 
-    with open (rst_outdir+raw_name+".rst", 'w', encoding='UTF-8') as file:
+    with open (rst_outdir+raw_name+".rst", "w", encoding="UTF-8") as file:
         file.write(title_name + middle_text + "../_static/" + f + "\n")
 
 text = """Examples
@@ -56,13 +56,11 @@ text = """Examples
 
 # Create outer index.rst for examples
 for f in files:
-    raw_name = f.split('.')[0]
+    raw_name = f.split(".")[0]
     text += "   /" + rst_outdir + raw_name + "\n"
 
-with open ("examples/index.rst", 'w', encoding='UTF-8') as file:
+with open ("examples/index.rst", "w", encoding="UTF-8") as file:
     file.write(text)
-
-
 
 
 # -- Project information -----------------------------------------------------
@@ -77,7 +75,7 @@ pkg_meta = _get_project_meta()
 project = str(pkg_meta["name"])
 author = ", ".join([person["name"] for person in pkg_meta["authors"]])
 organization = "Delv"
-copyright = f" {datetime.date.today().year}, {organization}" # pylint: disable=redefined-builtin
+copyright = f" {datetime.date.today().year}, {organization}"  # pylint: disable=redefined-builtin
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,11 @@ Welcome to elfpy's documentation!
    installation
 
 .. toctree::
+   :caption: Examples
+
+   /examples/index
+
+.. toctree::
    :titlesonly:
    :caption: API
 

--- a/examples/borrowing_agents_notebook.py
+++ b/examples/borrowing_agents_notebook.py
@@ -25,10 +25,6 @@ from __future__ import annotations
 # pylint: disable=redefined-outer-name
 # pyright: reportOptionalMemberAccess=false, reportGeneralTypeIssues=false
 
-
-# %% [markdown]
-# <a href="https://colab.research.google.com/github/delvtech/elf-simulations/blob/main/examples/notebooks/borrowing_beatrice.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
 # %% [markdown]
 # ## Hyperdrive Borrow market simulation
 # We use the following setup:

--- a/examples/hyperdrive_demo_notebook.py
+++ b/examples/hyperdrive_demo_notebook.py
@@ -25,9 +25,6 @@ from matplotlib.axes import Axes
 # pyright: reportOptionalMemberAccess=false, reportGeneralTypeIssues=false
 
 # %% [markdown]
-# <a href="https://colab.research.google.com/github/delvtech/elf-simulations/blob/4536bb486b7ce857840996448dbb479adb1c5c14/examples/notebooks/hyperdrive.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-# %% [markdown]
 # ## Hyperdrive Simulation
 # We use the following setup:
 # - 90 day term

--- a/examples/smart_short_long_agents_notebook.py
+++ b/examples/smart_short_long_agents_notebook.py
@@ -13,19 +13,6 @@ from __future__ import annotations
 # ### Install repo requirements & import packages
 
 # %%
-# test: skip-cell
-try:  # install dependencies only if running on google colab
-    # check if running in Google Colaboratory
-    eval("import google.colab")  # pylint: disable=eval-used
-    import os
-
-    os.system(
-        "!pip install git+https://github.com/delvtech/elf-simulations.git@4536bb486b7ce857840996448dbb479adb1c5c14"
-    )
-except:  # pylint: disable=bare-except
-    print("running locally & trusting that you have the dependencies installed")
-
-# %%
 import numpy as np
 from numpy.random._generator import Generator as NumpyGenerator
 import matplotlib.ticker as ticker

--- a/scripts/notebook_docs.sh
+++ b/scripts/notebook_docs.sh
@@ -1,11 +1,16 @@
-# Must run script from repo base dir, otherwise will exit
-outdir=docs/notebook_build/
-cd docs/ || exit 1;
-mkdir -p notebook_build
-# Clean up notebook_build direcotry
-rm notebook_build/*
-cd ../examples || exit 1;
+#!/bin/sh
 
+# Paths set to be relative to the location of this script
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+outdir=$parent_path/../docs/notebook_build/
+indir=$parent_path/../examples/
+
+mkdir -p $outdir
+# Clean up notebook_build direcotry
+rm $outdir/*
+
+cd $indir
 fail=0
 failed_files=()
 # Only do this for files ending in _notebook.py
@@ -20,7 +25,7 @@ do
     # jupytext outputs final html file to stdout, but we don't need it
     # since jupyter has already made the file, so send to /dev/null
     jupytext --to ipynb --pipe-fmt ipynb -o '-' --check \
-        "jupyter nbconvert --to html --execute --stdin --output ../$outdir/$outfn.html" $f > /dev/null;
+        "jupyter nbconvert --to html --execute --stdin --output $outdir/$outfn.html" $f > /dev/null;
     
     # Check output of jupytext, if it fails, keep running but store the fail flag for later
     if [[ $? -ne 0 ]]; then

--- a/scripts/notebook_docs.sh
+++ b/scripts/notebook_docs.sh
@@ -3,7 +3,7 @@
 # Paths set to be relative to the location of this script
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
-outdir=$parent_path/../docs/notebook_build/
+outdir=$parent_path/../docs/source/examples/_static/
 indir=$parent_path/../examples/
 
 mkdir -p $outdir


### PR DESCRIPTION
This PR allows for building in notebooks in `examples/*_notebooks.py` into html files that Sphinx docs link to:

<img width="1640" alt="Screenshot 2023-05-31 at 12 36 48 PM" src="https://github.com/delvtech/elf-simulations/assets/1431723/9f88dc8f-bdbf-4251-9d6b-91a1a2cc7120">
