### PR TITLE
Remove use of defaultdict

### DIFF
--- a/elfpy/markets/base.py
+++ b/elfpy/markets/base.py
@@ -1,7 +1,6 @@
 """Market simulators store state information when interfacing AMM pricing models with users."""
 from __future__ import annotations
 
-from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Generic, TypeVar
@@ -67,7 +66,7 @@ class BaseMarketState:
         """Returns a new copy of self"""
         raise NotImplementedError
 
-    def check_valid_market_state(self, dictionary: dict | defaultdict) -> BaseMarketState:
+    def check_valid_market_state(self, dictionary: dict | None = None) -> BaseMarketState:
         """Returns a new copy of self"""
         raise NotImplementedError
 

--- a/elfpy/markets/borrow.py
+++ b/elfpy/markets/borrow.py
@@ -109,15 +109,18 @@ class MarketState(base_market.BaseMarketState):
         """Returns a new copy of self"""
         return MarketState(**self.__dict__)
 
-    def check_valid_market_state(self, dictionary: dict) -> None:
+    def check_valid_market_state(self, dictionary: dict | None = None) -> None:
         """Test that all market state variables are greater than zero"""
-        for key, value in dictionary.items():
-            if isinstance(value, FixedPoint):
-                assert value >= FixedPoint(0), f"{key} attribute with {value=} must be >= 0."
-            elif isinstance(value, dict):
-                self.check_valid_market_state(value)
-            else:
-                pass  # noop; frozen, etc
+        if dictionary is None:
+            self.check_valid_market_state(self.__dict__)
+        else:
+            for key, value in dictionary.items():
+                if isinstance(value, FixedPoint):
+                    assert value >= FixedPoint(0), f"{key} attribute with {value=} must be >= 0."
+                elif isinstance(value, dict):
+                    self.check_valid_market_state(value)
+                else:
+                    pass  # noop; frozen, etc
 
 
 @types.freezable(frozen=False, no_new_attribs=True)

--- a/elfpy/markets/hyperdrive/checkpoint.py
+++ b/elfpy/markets/hyperdrive/checkpoint.py
@@ -1,0 +1,30 @@
+"""Checkpoint Class for a Hyperdrive Market."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from elfpy import FixedPoint
+
+
+@dataclass
+class Checkpoint:
+    """
+    Hyperdrive positions are bucketed into checkpoints, which allows us to avoid poking in any
+    period that has LP or trading activity. The checkpoints contain the starting share price from
+    the checkpoint as well as aggregate volume values.
+    """
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __setitem__(self, key, value):
+        return setattr(self, key, value)
+
+    share_price: FixedPoint = FixedPoint(0)
+    long_share_price: FixedPoint = FixedPoint(0)
+    long_base_volume: FixedPoint = FixedPoint(0)
+    short_base_volume: FixedPoint = FixedPoint(0)
+
+
+# all values zeroed
+DEFAULT_CHECKPOINT = Checkpoint()

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -1,9 +1,8 @@
-"DefaultDict" "Market simulators store state information when interfacing AMM pricing models with users." ""
+"""Market simulators store state information when interfacing AMM pricing models with users."""
 from __future__ import annotations
 
 import copy
 import logging
-from collections import defaultdict
 from dataclasses import dataclass, field
 
 import elfpy
@@ -15,34 +14,11 @@ import elfpy.pricing_models.hyperdrive as hyperdrive_pm
 import elfpy.time as time
 import elfpy.types as types
 import elfpy.utils.price as price_utils
+from elfpy.markets.hyperdrive.checkpoint import Checkpoint
 from elfpy.math import FixedPoint
 
 # dataclasses can have many attributes
 # pylint: disable=too-many-instance-attributes
-
-
-@dataclass
-class Checkpoint:
-    """
-    Hyperdrive positions are bucketed into checkpoints, which allows us to avoid poking in any
-    period that has LP or trading activity. The checkpoints contain the starting share price from
-    the checkpoint as well as aggregate volume values.
-    """
-
-    def __getitem__(self, key):
-        return getattr(self, key)
-
-    def __setitem__(self, key, value):
-        return setattr(self, key, value)
-
-    share_price: FixedPoint = FixedPoint(0)
-    long_share_price: FixedPoint = FixedPoint(0)
-    long_base_volume: FixedPoint = FixedPoint(0)
-    short_base_volume: FixedPoint = FixedPoint(0)
-
-
-# all values zeroed
-DEFAULT_CHECKPOINT = Checkpoint()
 
 
 @types.freezable(frozen=False, no_new_attribs=False)
@@ -89,13 +65,13 @@ class MarketState(base_market.BaseMarketState):
         The amount of base paid by outstanding longs.
     short_base_volume: FixedPoint
         The amount of base paid to outstanding shorts.
-    checkpoints: defaultdict[FixedPoint, Checkpoint]
+    checkpoints: dict[FixedPoint, elfpy.markets.hyperdrive.checkpoint.Checkpoint]
         Time delimited checkpoints
     checkpoint_duration: FixedPoint
         Time between checkpoints, defaults to 1 day
-    total_supply_longs: defaultdict[FixedPoint, FixedPoint]
+    total_supply_longs: dict[FixedPoint, FixedPoint]
         Checkpointed total supply for longs stored as {checkpoint_time: bond_amount}
-    total_supply_shorts: defaultdict[FixedPoint, FixedPoint]
+    total_supply_shorts: dict[FixedPoint, FixedPoint]
         Checkpointed total supply for shorts stored as {checkpoint_time: bond_amount}
     total_supply_withdraw_shares: FixedPoint
         Total amount of withdraw shares outstanding
@@ -131,11 +107,11 @@ class MarketState(base_market.BaseMarketState):
     short_average_maturity_time: FixedPoint = FixedPoint(0)
     long_base_volume: FixedPoint = FixedPoint(0)
     short_base_volume: FixedPoint = FixedPoint(0)
-    checkpoints: dict[FixedPoint, Checkpoint] = field(default_factory=lambda: {})
+    checkpoints: dict[FixedPoint, Checkpoint] = field(default_factory=dict)
     checkpoint_duration: FixedPoint = FixedPoint("1.0").div_up(FixedPoint("365.0"))
     checkpoint_duration_days: FixedPoint = FixedPoint("1.0")
-    total_supply_longs: dict[FixedPoint, FixedPoint] = field(default_factory=lambda: {})
-    total_supply_shorts: dict[FixedPoint, FixedPoint] = field(default_factory=lambda: {})
+    total_supply_longs: dict[FixedPoint, FixedPoint] = field(default_factory=dict)
+    total_supply_shorts: dict[FixedPoint, FixedPoint] = field(default_factory=dict)
     total_supply_withdraw_shares: FixedPoint = FixedPoint(0)
     withdraw_shares_ready_to_withdraw: FixedPoint = FixedPoint(0)
     withdraw_capital: FixedPoint = FixedPoint(0)
@@ -168,15 +144,15 @@ class MarketState(base_market.BaseMarketState):
         for mint_time, delta_checkpoint in delta.short_checkpoints.items():
             self.checkpoints.get(mint_time, Checkpoint()).short_base_volume += delta_checkpoint
         for mint_time, delta_supply in delta.total_supply_longs.items():
-            self.total_supply_longs[mint_time] += delta_supply
+            self.total_supply_longs[mint_time] = self.total_supply_longs.get(mint_time, FixedPoint(0)) + delta_supply
         for mint_time, delta_supply in delta.total_supply_shorts.items():
-            self.total_supply_shorts[mint_time] += delta_supply
+            self.total_supply_shorts[mint_time] = self.total_supply_shorts.get(mint_time, FixedPoint(0)) + delta_supply
 
     def copy(self) -> MarketState:
         """Returns a new copy of self"""
         return MarketState(**copy.deepcopy(self.__dict__))
 
-    def check_valid_market_state(self, dictionary: dict | defaultdict | None = None) -> None:
+    def check_valid_market_state(self, dictionary: dict | None = None) -> None:
         """Test that all market state variables are greater than zero"""
         if dictionary is None:
             dictionary = self.__dict__
@@ -480,7 +456,7 @@ class Market(
         # get default zero value if no checkpoint exists.
         checkpoint = self.market_state.checkpoints.get(self.latest_checkpoint_time, Checkpoint)
         long_share_price = checkpoint.long_share_price
-        total_supply = self.market_state.total_supply_longs[self.latest_checkpoint_time]
+        total_supply = self.market_state.total_supply_longs.get(self.latest_checkpoint_time, FixedPoint(0))
         updated_long_share_price = hyperdrive_actions.update_weighted_average(
             long_share_price, total_supply, self.market_state.share_price, bond_proceeds, True
         )
@@ -601,11 +577,12 @@ class Market(
         if checkpoint.share_price != FixedPoint(0) or checkpoint_time > self.block_time.time:
             return checkpoint.share_price
         # Create the share price checkpoint.
+        self.market_state.checkpoints[checkpoint_time] = Checkpoint()
         self.market_state.checkpoints[checkpoint_time].share_price = share_price
         mint_time = checkpoint_time - self.annualized_position_duration
         # Close out any matured long positions and pay out the long withdrawal pool for longs that
         # have matured.
-        matured_longs_amount = self.market_state.total_supply_longs[mint_time]
+        matured_longs_amount = self.market_state.total_supply_longs.get(mint_time, FixedPoint(0))
         if matured_longs_amount > FixedPoint(0):
             market_deltas, _ = hyperdrive_actions.calc_close_long(
                 wallet.Wallet(0).address,
@@ -620,7 +597,7 @@ class Market(
             self.market_state.apply_delta(market_deltas)
         # Close out any matured short positions and pay out the short withdrawal pool for shorts
         # that have matured.
-        matured_shorts_amount = self.market_state.total_supply_shorts[mint_time]
+        matured_shorts_amount = self.market_state.total_supply_shorts.get(mint_time, FixedPoint(0))
         if matured_shorts_amount > FixedPoint(0):
             checkpoint = self.market_state.checkpoints.get(mint_time, Checkpoint())
             open_share_price = checkpoint.share_price

--- a/elfpy/utils/apeworx_integrations.py
+++ b/elfpy/utils/apeworx_integrations.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Tuple
 
@@ -98,10 +98,10 @@ def get_market_state_from_contract(hyperdrive_contract: ContractInstance, **kwar
         short_average_maturity_time=FixedPoint(pool_state["shortAverageMaturityTime"]),
         long_base_volume=FixedPoint(pool_state["longBaseVolume"]),
         short_base_volume=FixedPoint(pool_state["shortBaseVolume"]),
-        # TODO: checkpoints=defaultdict
+        # TODO: checkpoints=dict
         checkpoint_duration=FixedPoint(hyper_config["checkpointDuration"]),
-        total_supply_longs=defaultdict(FixedPoint, {FixedPoint(0): FixedPoint(pool_state["longsOutstanding"])}),
-        total_supply_shorts=defaultdict(FixedPoint, {FixedPoint(0): FixedPoint(pool_state["shortsOutstanding"])}),
+        total_supply_longs={FixedPoint(0): FixedPoint(pool_state["longsOutstanding"])},
+        total_supply_shorts={FixedPoint(0): FixedPoint(pool_state["shortsOutstanding"])},
         total_supply_withdraw_shares=FixedPoint(total_supply_withdraw_shares),
         withdraw_shares_ready_to_withdraw=FixedPoint(pool_state["withdrawalSharesReadyToWithdraw"]),
         withdraw_capital=FixedPoint(pool_state["capital"]),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,4 +78,5 @@ exclude = [
     ".venv",
     "docs",
     "hyperdrive_solidity/.venv",
+    "hyperdrive_solidity",
 ]

--- a/tests/solidity/test_checkpoints.py
+++ b/tests/solidity/test_checkpoints.py
@@ -3,6 +3,7 @@
 import unittest
 
 import elfpy.agents.agent as elf_agent
+import elfpy.markets.hyperdrive.checkpoint
 import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_markets
 import elfpy.pricing_models.hyperdrive as hyperdrive_pm
 import elfpy.time as time
@@ -94,7 +95,7 @@ class TestCheckpoint(unittest.TestCase):
         )
 
         # get default zero value if no checkpoint exists.
-        checkpoint = self.hyperdrive.market_state.checkpoints.get(checkpoint_time, hyperdrive_markets.Checkpoint())
+        checkpoint = self.hyperdrive.market_state.checkpoints.get(checkpoint_time, elfpy.markets.hyperdrive.checkpoint.Checkpoint())
         # Ensure that the checkpoint contains the share price prior to the share price update.
         self.assertEqual(share_price_before, checkpoint.share_price)
         # Ensure that the long and short balance wasn't effected by the checkpoint (the long and
@@ -124,7 +125,7 @@ class TestCheckpoint(unittest.TestCase):
         # Ensure that the checkpoint contains the latest share price.
         # get default zero value if no checkpoint exists.
         checkpoint = self.hyperdrive.market_state.checkpoints.get(
-            self.hyperdrive.latest_checkpoint_time, hyperdrive_markets.Checkpoint()
+            self.hyperdrive.latest_checkpoint_time, elfpy.markets.hyperdrive.checkpoint.Checkpoint()
         )
         self.assertEqual(checkpoint.share_price, self.hyperdrive.market_state.share_price)
 
@@ -158,12 +159,12 @@ class TestCheckpoint(unittest.TestCase):
         # share price update.
         # get default zero value if no checkpoint exists.
         last_checkpoint = self.hyperdrive.market_state.checkpoints.get(
-            self.hyperdrive.latest_checkpoint_time, hyperdrive_markets.Checkpoint()
+            self.hyperdrive.latest_checkpoint_time, elfpy.markets.hyperdrive.checkpoint.Checkpoint()
         )
         self.assertEqual(last_checkpoint.share_price, self.hyperdrive.market_state.share_price)
         # Ensure that the previous checkpoint contains the closest share price.
         previous_checkpoint = self.hyperdrive.market_state.checkpoints.get(
-            previous_checkpoint_time, hyperdrive_markets.Checkpoint()
+            previous_checkpoint_time, elfpy.markets.hyperdrive.checkpoint.Checkpoint()
         )
         self.assertEqual(previous_checkpoint.share_price, self.hyperdrive.market_state.share_price)
         # Ensure that the long and short balance has gone to zero (all of the

--- a/tests/solidity/test_checkpoints.py
+++ b/tests/solidity/test_checkpoints.py
@@ -92,7 +92,9 @@ class TestCheckpoint(unittest.TestCase):
             apr_after,
             delta=self.APPROX_EQ,
         )
-        checkpoint = self.hyperdrive.market_state.checkpoints[checkpoint_time]
+
+        # get default zero value if no checkpoint exists.
+        checkpoint = self.hyperdrive.market_state.checkpoints.get(checkpoint_time, hyperdrive_markets.Checkpoint())
         # Ensure that the checkpoint contains the share price prior to the share price update.
         self.assertEqual(share_price_before, checkpoint.share_price)
         # Ensure that the long and short balance wasn't effected by the checkpoint (the long and
@@ -120,7 +122,10 @@ class TestCheckpoint(unittest.TestCase):
         )
         self.assertEqual(apr_after, apr_before)
         # Ensure that the checkpoint contains the latest share price.
-        checkpoint = self.hyperdrive.market_state.checkpoints[self.hyperdrive.latest_checkpoint_time]
+        # get default zero value if no checkpoint exists.
+        checkpoint = self.hyperdrive.market_state.checkpoints.get(
+            self.hyperdrive.latest_checkpoint_time, hyperdrive_markets.Checkpoint()
+        )
         self.assertEqual(checkpoint.share_price, self.hyperdrive.market_state.share_price)
 
     @unittest.skip("Checkpoint test breaking with mod bug fix")
@@ -151,10 +156,15 @@ class TestCheckpoint(unittest.TestCase):
 
         # Ensure that the checkpoint contains the share price prior to the
         # share price update.
-        last_checkpoint = self.hyperdrive.market_state.checkpoints[self.hyperdrive.latest_checkpoint_time]
+        # get default zero value if no checkpoint exists.
+        last_checkpoint = self.hyperdrive.market_state.checkpoints.get(
+            self.hyperdrive.latest_checkpoint_time, hyperdrive_markets.Checkpoint()
+        )
         self.assertEqual(last_checkpoint.share_price, self.hyperdrive.market_state.share_price)
         # Ensure that the previous checkpoint contains the closest share price.
-        previous_checkpoint = self.hyperdrive.market_state.checkpoints[previous_checkpoint_time]
+        previous_checkpoint = self.hyperdrive.market_state.checkpoints.get(
+            previous_checkpoint_time, hyperdrive_markets.Checkpoint()
+        )
         self.assertEqual(previous_checkpoint.share_price, self.hyperdrive.market_state.share_price)
         # Ensure that the long and short balance has gone to zero (all of the
         # matured positions have been closed).

--- a/tests/solidity/test_checkpoints.py
+++ b/tests/solidity/test_checkpoints.py
@@ -95,7 +95,9 @@ class TestCheckpoint(unittest.TestCase):
         )
 
         # get default zero value if no checkpoint exists.
-        checkpoint = self.hyperdrive.market_state.checkpoints.get(checkpoint_time, elfpy.markets.hyperdrive.checkpoint.Checkpoint())
+        checkpoint = self.hyperdrive.market_state.checkpoints.get(
+            checkpoint_time, elfpy.markets.hyperdrive.checkpoint.Checkpoint()
+        )
         # Ensure that the checkpoint contains the share price prior to the share price update.
         self.assertEqual(share_price_before, checkpoint.share_price)
         # Ensure that the long and short balance wasn't effected by the checkpoint (the long and

--- a/tests/solidity/test_close_long.py
+++ b/tests/solidity/test_close_long.py
@@ -2,6 +2,7 @@
 import unittest
 
 import elfpy.agents.agent as elf_agent
+from elfpy.markets.hyperdrive.checkpoint import Checkpoint
 import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
 import elfpy.pricing_models.hyperdrive as hyperdrive_pm
 import elfpy.time as time
@@ -125,11 +126,11 @@ class TestCloseLong(unittest.TestCase):
         )
         checkpoint_time = maturity_time - self.term_length
         self.assertEqual(  # checkpoint long base volume
-            self.hyperdrive.market_state.checkpoints[checkpoint_time].long_base_volume,
+            self.hyperdrive.market_state.checkpoints.get(checkpoint_time, Checkpoint()).long_base_volume,
             FixedPoint(0),
             msg=(
                 f"The long base volume at {checkpoint_time=} should be zero, "
-                f"not {self.hyperdrive.market_state.checkpoints[checkpoint_time].long_base_volume=}."
+                f"not {self.hyperdrive.market_state.checkpoints.get(checkpoint_time, Checkpoint()).long_base_volume=}."
             ),
         )
         self.assertEqual(  # shorts outstanding
@@ -151,11 +152,11 @@ class TestCloseLong(unittest.TestCase):
             msg=f"{self.hyperdrive.market_state.short_base_volume=} should be 0.",
         )
         self.assertEqual(  # checkpoint short base volume
-            self.hyperdrive.market_state.checkpoints[checkpoint_time].short_base_volume,
+            self.hyperdrive.market_state.checkpoints.get(checkpoint_time, Checkpoint()).short_base_volume,
             FixedPoint(0),
             msg=(
                 f"The short base volume should at {checkpoint_time=} be zero,"
-                f"not {self.hyperdrive.market_state.checkpoints[checkpoint_time].long_base_volume=}."
+                f"not {self.hyperdrive.market_state.checkpoints.get(checkpoint_time, Checkpoint()).long_base_volume=}."
             ),
         )
 
@@ -347,9 +348,8 @@ class TestCloseLong(unittest.TestCase):
         self.verify_close_long(
             example_agent=self.bob,
             market_state_before=market_state_before_close,
-            agent_base_paid=agent_deltas_open.longs[
-                FixedPoint(0)
-            ].balance,  # not starting amount since we're at maturity
+            # not starting amount since we're at maturity
+            agent_base_paid=agent_deltas_open.longs[FixedPoint(0)].balance,
             agent_base_proceeds=base_proceeds,
             bond_amount=agent_deltas_open.longs[FixedPoint(0)].balance,
             maturity_time=self.hyperdrive.position_duration.days / FixedPoint("365.0"),

--- a/tests/solidity/test_close_short.py
+++ b/tests/solidity/test_close_short.py
@@ -2,6 +2,7 @@
 import unittest
 
 import elfpy.agents.agent as elf_agent
+from elfpy.markets.hyperdrive.checkpoint import Checkpoint
 import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
 import elfpy.pricing_models.hyperdrive as hyperdrive_pm
 import elfpy.pricing_models.yieldspace as yieldspace_pm
@@ -128,11 +129,11 @@ class TestCloseShort(unittest.TestCase):
         )
         checkpoint_time = maturity_time - self.term_length
         self.assertEqual(  # checkpoint long base volume
-            self.hyperdrive.market_state.checkpoints[checkpoint_time].long_base_volume,
+            self.hyperdrive.market_state.checkpoints.get(checkpoint_time, Checkpoint()).long_base_volume,
             FixedPoint(0),
             msg=(
                 f"The long base volume at {checkpoint_time=} should be zero, "
-                f"not {self.hyperdrive.market_state.checkpoints[checkpoint_time].long_base_volume=}."
+                f"not {self.hyperdrive.market_state.checkpoints.get(checkpoint_time, Checkpoint()).long_base_volume=}."
             ),
         )
         self.assertEqual(  # shorts outstanding
@@ -152,7 +153,7 @@ class TestCloseShort(unittest.TestCase):
             msg="short_base_volume is wrong",
         )
         self.assertEqual(  # checkpoint short base volume
-            self.hyperdrive.market_state.checkpoints[checkpoint_time].short_base_volume,
+            self.hyperdrive.market_state.checkpoints.get(checkpoint_time, Checkpoint()).short_base_volume,
             FixedPoint(0),
             msg="checkpoint short base volume is wrong",
         )

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import unittest
-from collections import defaultdict
 
+import elfpy.markets.hyperdrive.checkpoint
 import elfpy.pricing_models.hyperdrive as hyperdrive_pm
 import elfpy.pricing_models.yieldspace as yieldspace_pm
 import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
@@ -316,34 +316,30 @@ class MarketTest(unittest.TestCase):
             market_state.check_valid_market_state()
         with self.assertRaises(AssertionError):
             market_state = hyperdrive_market.MarketState(
-                checkpoints=defaultdict(
-                    hyperdrive_market.Checkpoint,
-                    {FixedPoint(0): hyperdrive_market.Checkpoint(share_price=FixedPoint(-1.0))},
-                )
+                checkpoints={
+                    FixedPoint(0): elfpy.markets.hyperdrive.checkpoint.Checkpoint(share_price=FixedPoint(-1.0))
+                },
             )
             market_state.check_valid_market_state()
         with self.assertRaises(AssertionError):
             market_state = hyperdrive_market.MarketState(
-                checkpoints=defaultdict(
-                    hyperdrive_market.Checkpoint,
-                    {FixedPoint(0): hyperdrive_market.Checkpoint(long_share_price=FixedPoint(-1.0))},
-                ),
+                checkpoints={
+                    FixedPoint(0): elfpy.markets.hyperdrive.checkpoint.Checkpoint(long_share_price=FixedPoint(-1.0))
+                },
             )
             market_state.check_valid_market_state()
         with self.assertRaises(AssertionError):
             market_state = hyperdrive_market.MarketState(
-                checkpoints=defaultdict(
-                    hyperdrive_market.Checkpoint,
-                    {FixedPoint(0): hyperdrive_market.Checkpoint(long_base_volume=FixedPoint(-1.0))},
-                ),
+                checkpoints={
+                    FixedPoint(0): elfpy.markets.hyperdrive.checkpoint.Checkpoint(long_base_volume=FixedPoint(-1.0))
+                },
             )
             market_state.check_valid_market_state()
         with self.assertRaises(AssertionError):
             market_state = hyperdrive_market.MarketState(
-                checkpoints=defaultdict(
-                    hyperdrive_market.Checkpoint,
-                    {FixedPoint(0): hyperdrive_market.Checkpoint(short_base_volume=FixedPoint(-1.0))},
-                )
+                checkpoints={
+                    FixedPoint(0): elfpy.markets.hyperdrive.checkpoint.Checkpoint(short_base_volume=FixedPoint(-1.0))
+                },
             )
             market_state.check_valid_market_state()
         with self.assertRaises(AssertionError):
@@ -354,16 +350,15 @@ class MarketTest(unittest.TestCase):
             market_state.check_valid_market_state()
         with self.assertRaises(AssertionError):
             market_state = hyperdrive_market.MarketState(
-                total_supply_longs=defaultdict(
-                    FixedPoint,
-                    {FixedPoint(0): FixedPoint(0), FixedPoint(1): FixedPoint(10.0), FixedPoint(2): FixedPoint(-1.0)},
-                )
+                total_supply_longs={
+                    FixedPoint(0): FixedPoint(0),
+                    FixedPoint(1): FixedPoint(10.0),
+                    FixedPoint(2): FixedPoint(-1.0),
+                },
             )
             market_state.check_valid_market_state()
         with self.assertRaises(AssertionError):
-            market_state = hyperdrive_market.MarketState(
-                total_supply_shorts=defaultdict(FixedPoint, {FixedPoint(0): FixedPoint(-1.0)})
-            )
+            market_state = hyperdrive_market.MarketState(total_supply_shorts={FixedPoint(0): FixedPoint(-1.0)})
             market_state.check_valid_market_state()
         with self.assertRaises(AssertionError):
             market_state = hyperdrive_market.MarketState(total_supply_withdraw_shares=FixedPoint(-1.0))


### PR DESCRIPTION
Solidity will always a default value of zero instead of None in python.  We were trying to emulate this with defaultdict.  This had the unintended consequence of creating new entries if an unknown key was looked up.  We could either create a custom DefaultDict or just use the .get() method on dict to ensure that we always get a default zero value.  We chose the latter.

- defaultdict -> dict
- update callers
- update pyproject
- fix lint
