### PR TITLE
Start evm_bots refactors, add `HALT_ON_ERROR` option for running evm_bots

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -13,9 +13,6 @@ dependencies:
   - name: Aave
     github: aave/aave-v3-core
     version: 1.17.2
-  - name: Mocks
-    local: hyperdrive_solidity/test/
-    contracts_folder: src/contracts
 
 solidity:
   import_remapping:

--- a/elfpy/bots/BotInfo.py
+++ b/elfpy/bots/BotInfo.py
@@ -7,6 +7,7 @@ from typing import Type
 from elfpy.agents.agent import Agent
 
 
+# FIXME: Do we need this or can get combine with the Agent class?  I submit that we can.
 @dataclass
 class BotInfo:
     """Information about a bot.

--- a/elfpy/bots/BotInfo.py
+++ b/elfpy/bots/BotInfo.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections import namedtuple
+from dataclasses import dataclass
+from typing import Type
+
+from elfpy.agents.agent import Agent
+
+
+@dataclass
+class BotInfo:
+    """Information about a bot.
+    Attributes
+    ----------
+    policy : Type[Agent]
+        The agent's policy.
+    trade_chance : float
+        Percent chance that a agent gets to trade on a given block.
+    risk_threshold : float | None
+        The risk threshold for the agent.
+    budget : Budget[mean, std, min, max]
+        The budget for the agent.
+    risk : Risk[mean, std, min, max]
+        The risk for the agent.
+    index : int | None
+        The index of the agent in the list of ALL agents.
+    name : str
+        The name of the agent.
+    """
+
+    Budget = namedtuple("Budget", ["mean", "std", "min", "max"])
+    Risk = namedtuple("Risk", ["mean", "std", "min", "max"])
+    policy: Type[Agent]
+    trade_chance: float = 0.1
+    risk_threshold: float | None = None
+    budget: Budget = Budget(mean=5_000, std=2_000, min=1_000, max=10_000)
+    risk: Risk = Risk(mean=0.02, std=0.01, min=0.0, max=0.06)
+    index: int | None = None
+    name: str = "botty mcbotface"
+
+    def __repr__(self) -> str:
+        """Return a string representation of the object."""
+        return f"{self.name} " + ",".join(
+            [f"{key}={value}" if value else "" for key, value in self.__dict__.items() if key not in ["name", "policy"]]
+        )

--- a/elfpy/bots/bot_info.py
+++ b/elfpy/bots/bot_info.py
@@ -1,3 +1,4 @@
+"""Information for creating a bot."""
 from __future__ import annotations
 
 from collections import namedtuple

--- a/elfpy/bots/bot_info.py
+++ b/elfpy/bots/bot_info.py
@@ -8,7 +8,7 @@ from typing import Type
 from elfpy.agents.policies.base import BasePolicy
 
 
-# FIXME: Do we need this or can get combine with the Agent class?  I submit that we can.
+# TODO: Do we need this or can get combine with the Agent class?  I submit that we can.
 @dataclass
 class BotInfo:
     """Information about a bot.

--- a/elfpy/bots/bot_info.py
+++ b/elfpy/bots/bot_info.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from dataclasses import dataclass
 from typing import Type
 
-from elfpy.agents.agent import Agent
+from elfpy.agents.policies.base import BasePolicy
 
 
 # FIXME: Do we need this or can get combine with the Agent class?  I submit that we can.
@@ -32,7 +32,7 @@ class BotInfo:
 
     Budget = namedtuple("Budget", ["mean", "std", "min", "max"])
     Risk = namedtuple("Risk", ["mean", "std", "min", "max"])
-    policy: Type[Agent]
+    policy: Type[BasePolicy]
     trade_chance: float = 0.1
     risk_threshold: float | None = None
     budget: Budget = Budget(mean=5_000, std=2_000, min=1_000, max=10_000)

--- a/elfpy/bots/get_config.py
+++ b/elfpy/bots/get_config.py
@@ -13,8 +13,7 @@ from elfpy.bots.get_env_args import EnvironmentArguments
 from elfpy.simulators.config import Config
 
 
-# FIXME: define these args!  if we are going to accept command line args or environment variable
-# args, this would be a really good place to create something with attr.s so that we can do run time
+# TODO: this would be a really good place to create something with attr.s so that we can do run time
 # checking to make sure that nothing incorrect is passed in, so that we can avoid typo errors.
 def get_config(args: EnvironmentArguments) -> Config:
     """Instantiate a config object with elf-simulation parameters.

--- a/elfpy/bots/get_config.py
+++ b/elfpy/bots/get_config.py
@@ -9,13 +9,14 @@ from dotenv import load_dotenv
 import elfpy.utils.outputs as output_utils
 from elfpy.agents.policies import LongLouie, RandomAgent, ShortSally
 from elfpy.bots.bot_info import BotInfo
+from elfpy.bots.get_env_args import EnvironmentArguments
 from elfpy.simulators.config import Config
 
 
 # FIXME: define these args!  if we are going to accept command line args or environment variable
 # args, this would be a really good place to create something with attr.s so that we can do run time
 # checking to make sure that nothing incorrect is passed in, so that we can avoid typo errors.
-def get_config(args: dict) -> Config:
+def get_config(args: EnvironmentArguments) -> Config:
     """Instantiate a config object with elf-simulation parameters.
     Parameters
     ----------
@@ -29,8 +30,8 @@ def get_config(args: dict) -> Config:
     load_dotenv(dotenv_path=f"{Path.cwd() if Path.cwd().name != 'examples' else Path.cwd().parent}/.env")
     ape_logger.set_level(logging.ERROR)
     config = Config()
-    config.log_level = output_utils.text_to_log_level(args["log_level"])
-    random_seed_file = f".logging/random_seed{'_devnet' if args['devnet'] else ''}.txt"
+    config.log_level = output_utils.text_to_log_level(args.log_level)
+    random_seed_file = f".logging/random_seed{'_devnet' if args.devnet else ''}.txt"
     if os.path.exists(random_seed_file):
         with open(random_seed_file, "r", encoding="utf-8") as file:
             config.random_seed = int(file.read()) + 1
@@ -40,12 +41,12 @@ def get_config(args: dict) -> Config:
     with open(random_seed_file, "w", encoding="utf-8") as file:
         file.write(str(config.random_seed))
     config.title = "evm bots"
-    for key, value in args.items():
+    for key, value in args.__dict__.items():
         if hasattr(config, key):
             config[key] = value
         else:
             config.scratch[key] = value
-    config.log_filename += "_devnet" if args["devnet"] else ""
+    config.log_filename += "_devnet" if args.devnet else ""
 
     # Custom parameters for this experiment
     config.scratch["project_dir"] = Path.cwd().parent if Path.cwd().name == "examples" else Path.cwd()

--- a/elfpy/bots/get_config.py
+++ b/elfpy/bots/get_config.py
@@ -1,0 +1,58 @@
+"""Get configuration for a bot run."""
+import logging
+import os
+from pathlib import Path
+
+from ape.logging import logger as ape_logger
+from dotenv import load_dotenv
+
+import elfpy.utils.outputs as output_utils
+from elfpy.agents.policies import LongLouie, RandomAgent, ShortSally
+from elfpy.bots.bot_info import BotInfo
+from elfpy.simulators.config import Config
+
+
+# FIXME: define these args!  if we are going to accept command line args or environment variable
+# args, this would be a really good place to create something with attr.s so that we can do run time
+# checking to make sure that nothing incorrect is passed in, so that we can avoid typo errors.
+def get_config(args: dict) -> Config:
+    """Instantiate a config object with elf-simulation parameters.
+    Parameters
+    ----------
+    args : dict
+        The arguments from environmental variables.
+    Returns
+    -------
+    config : simulators.Config
+        The config object.
+    """
+    load_dotenv(dotenv_path=f"{Path.cwd() if Path.cwd().name != 'examples' else Path.cwd().parent}/.env")
+    ape_logger.set_level(logging.ERROR)
+    config = Config()
+    config.log_level = output_utils.text_to_log_level(args["log_level"])
+    random_seed_file = f".logging/random_seed{'_devnet' if args['devnet'] else ''}.txt"
+    if os.path.exists(random_seed_file):
+        with open(random_seed_file, "r", encoding="utf-8") as file:
+            config.random_seed = int(file.read()) + 1
+    else:  # make parent directory if it doesn't exist
+        os.makedirs(os.path.dirname(random_seed_file), exist_ok=True)
+    logging.info("Random seed=%s", config.random_seed)
+    with open(random_seed_file, "w", encoding="utf-8") as file:
+        file.write(str(config.random_seed))
+    config.title = "evm bots"
+    for key, value in args.items():
+        if hasattr(config, key):
+            config[key] = value
+        else:
+            config.scratch[key] = value
+    config.log_filename += "_devnet" if args["devnet"] else ""
+
+    # Custom parameters for this experiment
+    config.scratch["project_dir"] = Path.cwd().parent if Path.cwd().name == "examples" else Path.cwd()
+    config.scratch["louie"] = BotInfo(risk_threshold=0.0, policy=LongLouie, trade_chance=config.scratch["trade_chance"])
+    config.scratch["frida"] = BotInfo(policy=ShortSally, trade_chance=config.scratch["trade_chance"])
+    config.scratch["random"] = BotInfo(policy=RandomAgent, trade_chance=config.scratch["trade_chance"])
+    config.scratch["bot_names"] = {"louie", "frida", "random"}
+
+    config.freeze()
+    return config

--- a/elfpy/bots/get_env_args.py
+++ b/elfpy/bots/get_env_args.py
@@ -1,18 +1,17 @@
 """Get environment arguments for bots"""
 import os
 from dataclasses import dataclass
-from enum import Enum, auto
-from typing import Literal
+from enum import Enum
 
 from elfpy import DEFAULT_LOG_MAXBYTES
 
 
 class LogLevel(Enum):
-    DEBUG = auto()
-    INFO = auto()
-    WARNING = auto()
-    ERROR = auto()
-    CRITICAL = auto()
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
 
 
 # TODO: do we need this to be enviroment variables, why not add to the simulator Config?
@@ -31,7 +30,7 @@ class EnvironmentArguments:
     trade_chance: float = 0.1
     # Env passed in is a string "true"
     alchemy: bool = False
-    artifacts_url: str = "http://artifacts:80"
+    artifacts_url: str = "http://localhost:80"
 
 
 def get_env_args() -> EnvironmentArguments:
@@ -69,7 +68,7 @@ def get_env_args() -> EnvironmentArguments:
         trade_chance=float(os.environ.get("BOT_TRADE_CHANCE", 0.1)),
         # Env passed in is a string "true"
         alchemy=(os.environ.get("BOT_ALCHEMY", "false") == "true"),
-        artifacts_url=os.environ.get("BOT_ARTIFACTS_URL", "http://artifacts:80"),
+        artifacts_url=os.environ.get("BOT_ARTIFACTS_URL", "http://localhost:80"),
     )
 
     return args

--- a/elfpy/bots/get_env_args.py
+++ b/elfpy/bots/get_env_args.py
@@ -24,6 +24,9 @@ class EnvironmentArguments:
     temporary pattern until a better is made to pass arguments from docker compose scripts in the
     infra repo to evm_bots."""
 
+    # this will go away soon anyway when we add to config
+    # pylint: disable=too-many-instance-attributes
+
     # Env passed in is a string "true"
     halt_on_errors: bool = False
     devnet: bool = True

--- a/elfpy/bots/get_env_args.py
+++ b/elfpy/bots/get_env_args.py
@@ -1,11 +1,40 @@
 """Get environment arguments for bots"""
 import os
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Literal
 
 from elfpy import DEFAULT_LOG_MAXBYTES
 
 
-# FIXME: do we need this to be enviroment variables, why not add to the simulator Config?
-def get_env_args() -> dict:
+class LogLevel(Enum):
+    DEBUG = auto()
+    INFO = auto()
+    WARNING = auto()
+    ERROR = auto()
+    CRITICAL = auto()
+
+
+# TODO: do we need this to be enviroment variables, why not add to the simulator Config?
+@dataclass
+class EnvironmentArguments:
+    # Env passed in is a string "true"
+    halt_on_errors: bool = False
+    devnet: bool = True
+    rpc_url: str = "http://ethereum:8545"
+    log_filename: str = "testnet_bots"
+    log_level: LogLevel = LogLevel.INFO
+    max_bytes: int = DEFAULT_LOG_MAXBYTES
+    num_louie: int = 0
+    num_frida: int = 0
+    num_random: int = 4
+    trade_chance: float = 0.1
+    # Env passed in is a string "true"
+    alchemy: bool = False
+    artifacts_url: str = "http://artifacts:80"
+
+
+def get_env_args() -> EnvironmentArguments:
     """Define & parse arguments from stdin.
     List of arguments:
         log_filename : Optional output filename for logging. Default is "testnet_bots".
@@ -20,19 +49,27 @@ def get_env_args() -> dict:
     parser : dict
     """
 
-    args = {
+    # make sure we get a valid log level, default to INFO
+    log_level_str: str = os.environ.get("BOT_LOG_LEVEL", "INFO")
+    log_level = LogLevel.__members__.get(log_level_str)
+    if log_level is None:
+        log_level = LogLevel.INFO
+
+    args = EnvironmentArguments(
         # Env passed in is a string "true"
-        "devnet": (os.environ.get("BOT_DEVNET", "true") == "true"),
-        "rpc_url": os.environ.get("BOT_RPC_URL", "http://ethereum:8545"),
-        "log_filename": os.environ.get("BOT_LOG_FILENAME", "testnet_bots"),
-        "log_level": os.environ.get("BOT_LOG_LEVEL", "INFO"),
-        "max_bytes": int(os.environ.get("BOTS_MAX_BYTES", DEFAULT_LOG_MAXBYTES)),
-        "num_louie": int(os.environ.get("BOT_NUM_LOUIE", 0)),
-        "num_frida": int(os.environ.get("BOT_NUM_FRIDA", 0)),
-        "num_random": int(os.environ.get("BOT_NUM_RANDOM", 4)),
-        "trade_chance": float(os.environ.get("BOT_TRADE_CHANCE", 0.1)),
+        halt_on_errors=(os.environ.get("HALT_ON_ERRORS", "false") == "true"),
+        devnet=(os.environ.get("BOT_DEVNET", "true") == "true"),
+        rpc_url=os.environ.get("BOT_RPC_URL", "http://ethereum:8545"),
+        log_filename=os.environ.get("BOT_LOG_FILENAME", "testnet_bots"),
+        log_level=log_level,
+        max_bytes=int(os.environ.get("BOTS_MAX_BYTES", DEFAULT_LOG_MAXBYTES)),
+        num_louie=int(os.environ.get("BOT_NUM_LOUIE", 0)),
+        num_frida=int(os.environ.get("BOT_NUM_FRIDA", 0)),
+        num_random=int(os.environ.get("BOT_NUM_RANDOM", 4)),
+        trade_chance=float(os.environ.get("BOT_TRADE_CHANCE", 0.1)),
         # Env passed in is a string "true"
-        "alchemy": (os.environ.get("BOT_ALCHEMY", "false") == "true"),
-        "artifacts_url": os.environ.get("BOT_ARTIFACTS_URL", "http://artifacts:80"),
-    }
+        alchemy=(os.environ.get("BOT_ALCHEMY", "false") == "true"),
+        artifacts_url=os.environ.get("BOT_ARTIFACTS_URL", "http://artifacts:80"),
+    )
+
     return args

--- a/elfpy/bots/get_env_args.py
+++ b/elfpy/bots/get_env_args.py
@@ -1,0 +1,36 @@
+import os
+
+from elfpy import DEFAULT_LOG_MAXBYTES
+
+
+def get_env_args() -> dict:
+    """Define & parse arguments from stdin.
+    List of arguments:
+        log_filename : Optional output filename for logging. Default is "testnet_bots".
+        log_level : Logging level, should be in ["DEBUG", "INFO", "WARNING"]. Default is "INFO".
+        max_bytes : Maximum log file output size, in bytes. Default is 1MB.
+        num_louie : Number of Long Louie agents to run. Default is 0.
+        num_frida : Number of Fixed Rate Frida agents to run. Default is 0.
+        num_random: Number of Random agents to run. Default is 0.
+        trade_chance : Chance for a bot to execute a trade. Default is 0.1.
+    Returns
+    -------
+    parser : dict
+    """
+
+    args = {
+        # Env passed in is a string "true"
+        "devnet": (os.environ.get("BOT_DEVNET", "true") == "true"),
+        "rpc_url": os.environ.get("BOT_RPC_URL", "http://ethereum:8545"),
+        "log_filename": os.environ.get("BOT_LOG_FILENAME", "testnet_bots"),
+        "log_level": os.environ.get("BOT_LOG_LEVEL", "INFO"),
+        "max_bytes": int(os.environ.get("BOTS_MAX_BYTES", DEFAULT_LOG_MAXBYTES)),
+        "num_louie": int(os.environ.get("BOT_NUM_LOUIE", 0)),
+        "num_frida": int(os.environ.get("BOT_NUM_FRIDA", 0)),
+        "num_random": int(os.environ.get("BOT_NUM_RANDOM", 4)),
+        "trade_chance": float(os.environ.get("BOT_TRADE_CHANCE", 0.1)),
+        # Env passed in is a string "true"
+        "alchemy": (os.environ.get("BOT_ALCHEMY", "false") == "true"),
+        "artifacts_url": os.environ.get("BOT_ARTIFACTS_URL", "http://artifacts:80"),
+    }
+    return args

--- a/elfpy/bots/get_env_args.py
+++ b/elfpy/bots/get_env_args.py
@@ -7,6 +7,9 @@ from elfpy import DEFAULT_LOG_MAXBYTES
 
 
 class LogLevel(Enum):
+    """Logging Level Names.  These are the levels we've decided to use.  Values correspond to the
+    values found in the logging lib and can be access with logging.getLogLevel"""
+
     DEBUG = "DEBUG"
     INFO = "INFO"
     WARNING = "WARNING"
@@ -17,10 +20,14 @@ class LogLevel(Enum):
 # TODO: do we need this to be enviroment variables, why not add to the simulator Config?
 @dataclass
 class EnvironmentArguments:
+    """Environment arguments that can be set either locally or passed from docker.  This is a
+    temporary pattern until a better is made to pass arguments from docker compose scripts in the
+    infra repo to evm_bots."""
+
     # Env passed in is a string "true"
     halt_on_errors: bool = False
     devnet: bool = True
-    rpc_url: str = "http://ethereum:8545"
+    rpc_url: str = "http://localhost:8545"
     log_filename: str = "testnet_bots"
     log_level: LogLevel = LogLevel.INFO
     max_bytes: int = DEFAULT_LOG_MAXBYTES
@@ -58,7 +65,7 @@ def get_env_args() -> EnvironmentArguments:
         # Env passed in is a string "true"
         halt_on_errors=(os.environ.get("HALT_ON_ERRORS", "false") == "true"),
         devnet=(os.environ.get("BOT_DEVNET", "true") == "true"),
-        rpc_url=os.environ.get("BOT_RPC_URL", "http://ethereum:8545"),
+        rpc_url=os.environ.get("BOT_RPC_URL", "http://localhost:8545"),
         log_filename=os.environ.get("BOT_LOG_FILENAME", "testnet_bots"),
         log_level=log_level,
         max_bytes=int(os.environ.get("BOTS_MAX_BYTES", DEFAULT_LOG_MAXBYTES)),

--- a/elfpy/bots/get_env_args.py
+++ b/elfpy/bots/get_env_args.py
@@ -1,8 +1,10 @@
+"""Get environment arguments for bots"""
 import os
 
 from elfpy import DEFAULT_LOG_MAXBYTES
 
 
+# FIXME: do we need this to be enviroment variables, why not add to the simulator Config?
 def get_env_args() -> dict:
     """Define & parse arguments from stdin.
     List of arguments:

--- a/elfpy/utils/outputs.py
+++ b/elfpy/utils/outputs.py
@@ -1,22 +1,24 @@
 """Helper functions for delivering simulation outputs"""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-import os
-import sys
 import json
 import logging
+import os
+import sys
 from logging.handlers import RotatingFileHandler
+from typing import TYPE_CHECKING
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib import gridspec
 
 import elfpy
+from elfpy.bots.get_env_args import LogLevel
 from elfpy.math.fixed_point import FixedPoint
 
 if TYPE_CHECKING:
-    from typing import Optional, Any
+    from typing import Any, Optional
+
     import pandas as pd
     from matplotlib.figure import Figure
     from matplotlib.gridspec import GridSpec
@@ -442,7 +444,7 @@ def setup_logging(
             os.remove(os.path.join(log_dir, log_name))
         handler = RotatingFileHandler(os.path.join(log_dir, log_name), mode="w", maxBytes=max_bytes)
 
-    logging.getLogger().setLevel(log_level)  # events of this level and above will be tracked
+    logging.getLogger().setLevel(log_level.value)  # events of this level and above will be tracked
     handler.setFormatter(logging.Formatter(elfpy.DEFAULT_LOG_FORMATTER, elfpy.DEFAULT_LOG_DATETIME))
     logging.getLogger().handlers = [handler]  # overwrite handlers with the desired one
 
@@ -460,7 +462,7 @@ def close_logging(delete_logs=True):
             handler.close()
 
 
-def text_to_log_level(logging_text: str) -> int:
+def text_to_log_level(log_level: LogLevel) -> int:
     r"""Converts logging level description to an integer
 
     Arguments
@@ -473,20 +475,10 @@ def text_to_log_level(logging_text: str) -> int:
     int
         Logging level integer corresponding to the string input
     """
-    if logging_text.lower() == "notset":
-        level = logging.NOTSET
-    elif logging_text.lower() == "debug":
-        level = logging.DEBUG
-    elif logging_text.lower() == "info":
-        level = logging.INFO
-    elif logging_text.lower() == "warning":
-        level = logging.WARNING
-    elif logging_text.lower() == "error":
-        level = logging.ERROR
-    elif logging_text.lower() == "critical":
-        level = logging.CRITICAL
-    else:
-        raise ValueError(f'{logging_text=} must be in ["debug", "info", "warning", "error", "critical"]')
+
+    level: int = logging.getLevelName(log_level.value)
+    if not isinstance(level, int):
+        raise ValueError(f'{log_level=} must be in ["debug", "info", "warning", "error", "critical"]')
     return level
 
 

--- a/elfpy/utils/outputs.py
+++ b/elfpy/utils/outputs.py
@@ -444,7 +444,7 @@ def setup_logging(
             os.remove(os.path.join(log_dir, log_name))
         handler = RotatingFileHandler(os.path.join(log_dir, log_name), mode="w", maxBytes=max_bytes)
 
-    logging.getLogger().setLevel(log_level.value)  # events of this level and above will be tracked
+    logging.getLogger().setLevel(log_level)  # events of this level and above will be tracked
     handler.setFormatter(logging.Formatter(elfpy.DEFAULT_LOG_FORMATTER, elfpy.DEFAULT_LOG_DATETIME))
     logging.getLogger().handlers = [handler]  # overwrite handlers with the desired one
 

--- a/examples/borrowing_agents_notebook.py
+++ b/examples/borrowing_agents_notebook.py
@@ -18,6 +18,8 @@
 """Simulation for the Hyperdrive Borrow market"""
 from __future__ import annotations
 
+from elfpy.bots.get_env_args import LogLevel
+
 # pylint: disable=line-too-long
 # pylint: disable=too-many-lines
 # pylint: disable=too-many-arguments
@@ -56,21 +58,20 @@ except:  # pylint: disable=bare-except
 from dataclasses import dataclass, field
 
 import numpy as np
-from numpy.random._generator import Generator as NumpyGenerator
 import pandas as pd
+from numpy.random._generator import Generator as NumpyGenerator
 
 import elfpy.time as elf_time
 import elfpy.types as types
 import elfpy.utils.outputs as output_utils
-
 from elfpy.agents.agent import Agent
 from elfpy.agents.policies.base import BasePolicy
 from elfpy.markets.borrow import (
     BorrowMarket,
     BorrowMarketAction,
     BorrowMarketState,
-    MarketActionType,
     BorrowPricingModel,
+    MarketActionType,
 )
 from elfpy.math.fixed_point import FixedPoint
 from elfpy.simulators.config import Config
@@ -167,7 +168,9 @@ config.flat_fee_multiple = 0.05  # fee collected on the spread of the flat porti
 config.target_fixed_apr = 0.01  # target fixed APR of the initial market after the LP
 config.target_liquidity = 500_000_000  # target total liquidity of the initial market, before any trades
 
-config.log_level = output_utils.text_to_log_level("INFO")  # Logging level, should be in ["DEBUG", "INFO", "WARNING"]
+config.log_level = output_utils.text_to_log_level(
+    LogLevel.INFO
+)  # Logging level, should be in ["DEBUG", "INFO", "WARNING"]
 config.log_filename = "borrowing_beatrice"  # Output filename for logging
 
 config.shuffle_users = True

--- a/examples/borrowing_agents_notebook.py
+++ b/examples/borrowing_agents_notebook.py
@@ -18,7 +18,6 @@
 """Simulation for the Hyperdrive Borrow market"""
 from __future__ import annotations
 
-from elfpy.bots.get_env_args import LogLevel
 
 # pylint: disable=line-too-long
 # pylint: disable=too-many-lines
@@ -66,6 +65,7 @@ import elfpy.types as types
 import elfpy.utils.outputs as output_utils
 from elfpy.agents.agent import Agent
 from elfpy.agents.policies.base import BasePolicy
+from elfpy.bots.get_env_args import LogLevel
 from elfpy.markets.borrow import (
     BorrowMarket,
     BorrowMarketAction,

--- a/examples/evm_bots.py
+++ b/examples/evm_bots.py
@@ -37,7 +37,7 @@ from elfpy import SECONDS_IN_YEAR, types
 from elfpy.agents.agent import Agent
 from elfpy.agents.policies import LongLouie, RandomAgent, ShortSally
 from elfpy.agents.policies.base import BasePolicy
-from elfpy.bots.BotInfo import BotInfo
+from elfpy.bots.bot_info import BotInfo
 from elfpy.bots.get_env_args import get_env_args
 from elfpy.markets.base import BaseMarket, BasePricingModel
 from elfpy.markets.hyperdrive import HyperdrivePricingModel

--- a/examples/hyperdrive_demo_notebook.py
+++ b/examples/hyperdrive_demo_notebook.py
@@ -17,7 +17,10 @@
 # %%
 """simulation for the Hyperdrive market"""
 from __future__ import annotations
+
 from matplotlib.axes import Axes
+
+from elfpy.bots.get_env_args import LogLevel
 
 # pylint: disable=line-too-long
 # pylint: disable=too-many-lines
@@ -51,16 +54,16 @@ try:  # install repo only if running on google colab
 except:  # pylint: disable=bare-except
     print("running locally & trusting that you have the dependencies installed")
 
+import matplotlib.pyplot as plt
+
 # %%
 import numpy as np
-import matplotlib.pyplot as plt
 import pandas as pd
 from numpy.random._generator import Generator as NumpyGenerator
 
 import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.utils.outputs as output_utils
 import elfpy.utils.post_processing as post_processing
-
 from elfpy.agents.agent import Agent
 from elfpy.agents.policies import RandomAgent
 from elfpy.math import FixedPoint
@@ -68,7 +71,6 @@ from elfpy.simulators.config import Config
 from elfpy.utils import sim_utils
 from elfpy.utils.outputs import get_gridspec_subplots
 from elfpy.wallet.wallet import Wallet
-
 
 # %% [markdown]
 # ### Setup experiment parameters
@@ -94,7 +96,9 @@ trade_chance = 2 / (
 config.target_fixed_apr = 0.01  # target fixed APR of the initial market after the LP
 config.target_liquidity = 500_000_000  # target total liquidity of the initial market, before any trades
 
-config.log_level = output_utils.text_to_log_level("WARNING")  # Logging level, should be in ["DEBUG", "INFO", "WARNING"]
+config.log_level = output_utils.text_to_log_level(
+    LogLevel.WARNING
+)  # Logging level, should be in ["DEBUG", "INFO", "WARNING"]
 config.log_filename = "hyperdrive"  # Output filename for logging
 
 # %% [markdown]

--- a/examples/hyperdrive_demo_notebook.py
+++ b/examples/hyperdrive_demo_notebook.py
@@ -53,7 +53,6 @@ except:  # pylint: disable=bare-except
     print("running locally & trusting that you have the dependencies installed")
 
 
-
 # %%
 import numpy as np
 import pandas as pd

--- a/examples/hyperdrive_demo_notebook.py
+++ b/examples/hyperdrive_demo_notebook.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 
 from matplotlib.axes import Axes
 
-from elfpy.bots.get_env_args import LogLevel
-
 # pylint: disable=line-too-long
 # pylint: disable=too-many-lines
 # pylint: disable=invalid-name
@@ -54,11 +52,12 @@ try:  # install repo only if running on google colab
 except:  # pylint: disable=bare-except
     print("running locally & trusting that you have the dependencies installed")
 
-import matplotlib.pyplot as plt
+
 
 # %%
 import numpy as np
 import pandas as pd
+import matplotlib.pyplot as plt
 from numpy.random._generator import Generator as NumpyGenerator
 
 import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
@@ -66,6 +65,7 @@ import elfpy.utils.outputs as output_utils
 import elfpy.utils.post_processing as post_processing
 from elfpy.agents.agent import Agent
 from elfpy.agents.policies import RandomAgent
+from elfpy.bots.get_env_args import LogLevel
 from elfpy.math import FixedPoint
 from elfpy.simulators.config import Config
 from elfpy.utils import sim_utils

--- a/examples/smart_short_long_agents_notebook.py
+++ b/examples/smart_short_long_agents_notebook.py
@@ -2,6 +2,25 @@
 """Simulation for the smart bots making rational trades"""
 from __future__ import annotations
 
+import logging
+
+import matplotlib.ticker as ticker
+
+# %%
+import numpy as np
+from numpy.random._generator import Generator as NumpyGenerator
+
+import elfpy.types as types
+import elfpy.utils.outputs as output_utils
+import elfpy.utils.post_processing as post_processing
+import elfpy.utils.sim_utils as sim_utils
+from elfpy.agents.agent import Agent
+from elfpy.agents.policies import LongLouie, ShortSally
+from elfpy.agents.policies.base import BasePolicy
+from elfpy.markets.hyperdrive import HyperdriveMarket, hyperdrive_actions
+from elfpy.math import FixedPoint
+from elfpy.simulators.config import Config
+from elfpy.wallet.wallet import Wallet
 
 # pylint: disable=line-too-long
 # pylint: disable=too-many-lines
@@ -13,23 +32,6 @@ from __future__ import annotations
 # %% [markdown]
 # ### Install repo requirements & import packages
 
-# %%
-import numpy as np
-from numpy.random._generator import Generator as NumpyGenerator
-import matplotlib.ticker as ticker
-
-import elfpy.utils.outputs as output_utils
-import elfpy.utils.post_processing as post_processing
-import elfpy.utils.sim_utils as sim_utils
-import elfpy.types as types
-
-from elfpy.agents.agent import Agent
-from elfpy.agents.policies.base import BasePolicy
-from elfpy.wallet.wallet import Wallet
-from elfpy.markets.hyperdrive import hyperdrive_actions, HyperdriveMarket
-from elfpy.math import FixedPoint
-from elfpy.simulators.config import Config
-from elfpy.agents.policies import LongLouie, ShortSally
 
 # %% [markdown]
 # ### Setup experiment parameters
@@ -51,7 +53,7 @@ config.flat_fee_multiple = 0.05  # fee collected on the spread of the flat porti
 config.target_fixed_apr = 0.01  # target fixed APR of the initial market after the LP
 config.target_liquidity = 500_000_000  # target total liquidity of the initial market, before any trades
 
-config.log_level = output_utils.text_to_log_level("DEBUG")  # Logging level, should be in ["DEBUG", "INFO", "WARNING"]
+config.log_level = logging.DEBUG  # Logging level, should be in ["DEBUG", "INFO", "WARNING"]
 config.log_filename = "sally_n_louie"  # Output filename for logging
 
 config.shuffle_users = True

--- a/examples/vault_tracker_notebook.py
+++ b/examples/vault_tracker_notebook.py
@@ -1,6 +1,7 @@
 """Agent that tracks the vault apr"""
 # %%
 from __future__ import annotations
+import logging
 
 import os
 
@@ -150,7 +151,9 @@ config.random_seed = 123
 
 config.log_filename = "vault_tracker"  # Output filename for logging
 
-config.log_level = "DEBUG"  # Logging level, should be in ["DEBUG", "INFO", "WARNING"]. ERROR to suppress all logging.
+config.log_level = (
+    logging.DEBUG
+)  # Logging level, should be in ["DEBUG", "INFO", "WARNING"]. ERROR to suppress all logging.
 config.pricing_model_name = "Hyperdrive"  # can be yieldspace or hyperdrive
 
 config.num_trading_days = 365  # Number of simulated trading days, default is 180
@@ -394,10 +397,7 @@ if os.path.exists(config.log_filename):
     os.remove(config.log_filename)
 
 # define root logging parameters
-output_utils.setup_logging(
-    log_filename=config.log_filename,
-    log_level=output_utils.text_to_log_level(config.log_level),
-)
+output_utils.setup_logging(log_filename=config.log_filename, log_level=logging.DEBUG)
 
 simulator = sim_utils.get_simulator(config)
 simulator.collect_and_execute_trades()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -8,7 +8,6 @@ import sys
 import unittest
 
 import elfpy.utils.outputs as output_utils
-from elfpy.bots.get_env_args import LogLevel
 from elfpy.simulators.config import Config
 from elfpy.utils import sim_utils
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,13 +1,14 @@
 """Testing for logging in the ElfPy package modules"""
 from __future__ import annotations
 
-import unittest
-import logging
 import itertools
+import logging
 import os
 import sys
+import unittest
 
 import elfpy.utils.outputs as output_utils
+from elfpy.bots.get_env_args import LogLevel
 from elfpy.simulators.config import Config
 from elfpy.utils import sim_utils
 
@@ -62,12 +63,3 @@ class TestLogging(unittest.TestCase):
         logging.info("%s", config)
         self.assertLogs(level=logging.INFO)
         output_utils.close_logging()
-
-    def test_text_to_logging_level(self):
-        """Test that logging level strings result in the correct integera amounts"""
-        # change up case to test .lower()
-        logging_levels = ["notset", "debug", "info", "Warning", "Error", "CRITICAL"]
-        logging_constants = [0, 10, 20, 30, 40, 50]
-        for level_str, level_int in zip(logging_levels, logging_constants):
-            func_level = output_utils.text_to_log_level(level_str)
-            assert level_int == func_level

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,21 +1,24 @@
 # %%
 """Utilities to transform from elf-simulations to Ape objects."""
 from __future__ import annotations
+
 import unittest
 from pathlib import Path
-from ape.api import ReceiptAPI
 
 import ape
+from ape.api import ReceiptAPI
+
 import elfpy
-from elfpy.agents.agent import Agent
 import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
-import elfpy.utils.outputs as output_utils
 import elfpy.markets.hyperdrive.hyperdrive_pricing_model as hyperdrive_pm
+import elfpy.utils.apeworx_integrations as ape_utils
+import elfpy.utils.outputs as output_utils
+import elfpy.utils.transformers as trans_utils
+from elfpy.agents.agent import Agent
 from elfpy.agents.policies import RandomAgent
+from elfpy.bots.get_env_args import LogLevel
 from elfpy.simulators.config import Config
 from elfpy.utils import sim_utils
-import elfpy.utils.apeworx_integrations as ape_utils
-import elfpy.utils.transformers as trans_utils
 
 
 class TransformerTest(unittest.TestCase):
@@ -40,7 +43,7 @@ class TransformerTest(unittest.TestCase):
         config.target_liquidity = 500_000_000  # target total liquidity of the initial market, before any trades
 
         config.log_level = output_utils.text_to_log_level(
-            "WARNING"
+            LogLevel.ERROR
         )  # Logging level, should be in ["DEBUG", "INFO", "WARNING"]
         config.log_filename = "transformers"  # Output filename for logging
         config.freeze()


### PR DESCRIPTION
This PR does two things
  Start the process of splitting up evm_bots.
  Adds a halt_on_error option so that a failed transaction will not stop the bots from running.

Cleanups were made along the way while moving functions out of evm bots.
