### PR TITLE
transaction output now includes some additional log data

### DIFF
--- a/data/acquire_state.py
+++ b/data/acquire_state.py
@@ -106,9 +106,9 @@ def get_smart_contract_read_call(contract: Contract, function_name: str, **funct
 
 def setup_web3(ethereum_node: URI | str) -> Web3:
     """Create the Web3 provider and inject a geth Proof of Authority (poa) middleware."""
-    web3 = Web3(Web3.HTTPProvider(ethereum_node))
-    web3.middleware_onion.inject(geth_poa.geth_poa_middleware, layer=0)
-    return web3
+    web3_container = Web3(Web3.HTTPProvider(ethereum_node))
+    web3_container.middleware_onion.inject(geth_poa.geth_poa_middleware, layer=0)
+    return web3_container
 
 
 @attr.s

--- a/data/acquire_transactions.py
+++ b/data/acquire_transactions.py
@@ -59,7 +59,9 @@ def recursive_dict_conversion(obj):
     return obj
 
 
-def get_event_object(web3: Web3, contract: Contract, log: LogReceipt, tx_receipt: TxReceipt) -> Iterable[EventData]:
+def get_event_object(
+    web3_container: Web3, contract: Contract, log: LogReceipt, tx_receipt: TxReceipt
+) -> Iterable[EventData]:
     """Retrieves the event object and anonymous types for a  given contract and log"""
     abi_events = [abi for abi in contract.abi if abi["type"] == "event"]
     for event in abi_events:
@@ -69,7 +71,7 @@ def get_event_object(web3: Web3, contract: Contract, log: LogReceipt, tx_receipt
         inputs = ",".join(inputs)
         # Hash event signature
         event_signature_text = f"{name}({inputs})"
-        event_signature_hex = web3.keccak(text=event_signature_text).hex()
+        event_signature_hex = web3_container.keccak(text=event_signature_text).hex()
         # Find match between log's event signature and ABI's event signature
         receipt_event_signature_hex = log["topics"][0].hex()
         if event_signature_hex == receipt_event_signature_hex:


### PR DESCRIPTION
We're still missing the following columns:
```
        "args.operator": "operator",# missing
        "args.from": "from", # missing
        "args.to": "to", # missing
        "args.id": "id", # missing
        "args.value": "value", # missing
        "prefix": "prefix", # missing
```

And you'll notice that the new code does not replicate all of the functions of the old code (which did not run).