### PR TITLE
Add Flask server to create/list/kill python scripts.

### DIFF
--- a/elfpy/bots/bot_server.py
+++ b/elfpy/bots/bot_server.py
@@ -27,10 +27,9 @@ def run_script():
     # Execute the python script with the provided JSON as an argument
     script_id = len(running_processes) + 1
     script_path = app.config["SCRIPT_PATH"]
-    process = subprocess.Popen(["python", script_path, temp_file_path])
-
-    # Store the process in the dictionary
-    running_processes[script_id] = process
+    with subprocess.Popen(["python", script_path, temp_file_path]) as process:
+        # Store the process in the dictionary
+        running_processes[script_id] = process
 
     return jsonify({"id": script_id}), 200
 
@@ -51,8 +50,8 @@ def kill_script():
         process.kill()
         del running_processes[script_id]
         return jsonify({"message": f"Script with ID {script_id} has been killed."}), 200
-    else:
-        return jsonify({"message": f"Script with ID {script_id} is not running."}), 404
+
+    return jsonify({"message": f"Script with ID {script_id} is not running."}), 404
 
 
 @app.route("/list_processes", methods=["GET"])

--- a/elfpy/bots/bot_server.py
+++ b/elfpy/bots/bot_server.py
@@ -1,0 +1,73 @@
+"""A simple Flask server to run python scripts."""
+import json
+import subprocess
+import sys
+import tempfile
+
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+# Store the running processes and their corresponding IDs
+running_processes: dict[int, subprocess.Popen] = {}
+
+
+@app.route("/run_script", methods=["POST"])
+def run_script():
+    """Run a python script and return the script id."""
+    # TODO: validate the json
+    data = request.json
+
+    # Save the JSON payload to a temporary file
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        json_data = json.dumps(data).encode("utf-8")
+        temp_file.write(json_data)
+        temp_file_path = temp_file.name
+
+    # Execute the python script with the provided JSON as an argument
+    script_id = len(running_processes) + 1
+    script_path = app.config["SCRIPT_PATH"]
+    process = subprocess.Popen(["python", script_path, temp_file_path])
+
+    # Store the process in the dictionary
+    running_processes[script_id] = process
+
+    return jsonify({"id": script_id}), 200
+
+
+@app.route("/kill_script", methods=["POST"])
+def kill_script():
+    """Kill a running python script."""
+    if not request.json:
+        return jsonify({"message": "Invalid request. Please provide a valid ID."}), 400
+    try:
+        script_id = int(request.json["id"])
+    except (KeyError, ValueError):
+        return jsonify({"message": "Invalid request. Please provide a valid ID."}), 400
+
+    # Check if the script is running
+    if script_id in running_processes:
+        process = running_processes[script_id]
+        process.kill()
+        del running_processes[script_id]
+        return jsonify({"message": f"Script with ID {script_id} has been killed."}), 200
+    else:
+        return jsonify({"message": f"Script with ID {script_id} is not running."}), 404
+
+
+@app.route("/list_processes", methods=["GET"])
+def list_processes():
+    """List all running python scripts."""
+    process_list = [{"id": script_id, "status": process.poll()} for script_id, process in running_processes.items()]
+    return jsonify({"processes": process_list}), 200
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python app.py <script_path>")
+        sys.exit(1)
+
+    SCRIPT_PATH = sys.argv[1]
+    app.config["SCRIPT_PATH"] = SCRIPT_PATH
+
+    app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ web3
 # Hackweek requirements
 streamlit
 mplfinance
+flask


### PR DESCRIPTION
This PR adds a simple flask server that lets us spin up/down evm_bot processes (or any other python script).  The process now looks like this in development:
in infra: `dc up -d`
in elf_simulations: 
```bash
❯❯ python elfpy/bots/bot_server.py examples/evm_bots.py
```
then in a different terminal:
```bash
❯❯ curl -X POST -H "Content-Type: application/json" -d @my_config.json http://127.0.0.1:5000/run_script
❯❯ curl -X GET -H "Content-Type: application/json" http://127.0.0.1:5000/list_processes
❯❯ curl -X POST -H "Content-Type: application/json" -d '{"id": 1}' http://127.0.0.1:5000/kill_script
```

Note that this does not prevent anyone from still using evm_bots.py directly.  If we want, we can build more architecture to make things more streamlined locally.  This mostly helps us with our dockerized bot container deployments.