### PR TITLE
Migrate agent creation from ape_utils to contract_interface & code cleanup

### DIFF
--- a/elfpy/data/acquire_data.py
+++ b/elfpy/data/acquire_data.py
@@ -37,7 +37,10 @@ def main(
     )
     # get pool config from hyperdrive contract
     config_file = os.path.join(save_dir, "hyperdrive_config.json")
-    contract_interface.hyperdrive_config_to_json(config_file, state_hyperdrive_contract)
+    config_dict = contract_interface.get_hyperdrive_config(state_hyperdrive_contract)
+    logging.info("Writing pool config.")
+    with open(config_file, mode="w", encoding="UTF-8") as file:
+        json.dump(config_dict, file, indent=2, cls=output_utils.ExtendedJSONEncoder)
     # write the initial pool info
     block_number: BlockNumber = BlockNumber(start_block)
     latest_block_number = web3.eth.get_block_number()
@@ -45,9 +48,7 @@ def main(
     if (latest_block_number - block_number) > lookback_block_limit:
         block_number = BlockNumber(latest_block_number - lookback_block_limit)
         logging.warning("Starting block is past lookback block limit, starting at block %s", block_number)
-
     pool_info = []
-
     block_pool_info: dict = contract_interface.get_block_pool_info(web3, state_hyperdrive_contract, block_number)
     pool_info.append(block_pool_info)
     pool_info_file = os.path.join(save_dir, "hyperdrive_pool_info.json")

--- a/elfpy/data/acquire_data.py
+++ b/elfpy/data/acquire_data.py
@@ -28,7 +28,7 @@ def main(
     """Main entry point for accessing contract & writing pool info"""
     # pylint: disable=too-many-locals
     # get web3 provider
-    web3: Web3 = contract_interface.setup_web3(ethereum_node)
+    web3: Web3 = contract_interface.initialize_web3_with_http_provider(ethereum_node, request_kwargs={"timeout": 60})
     # send a request to the local server to fetch the deployed contract addresses and
     # load the deployed Hyperdrive contract addresses from the server response
     state_hyperdrive_contract = contract_interface.get_hyperdrive_contract(state_abi_file_path, contracts_url, web3)

--- a/elfpy/data/acquire_data.py
+++ b/elfpy/data/acquire_data.py
@@ -28,21 +28,19 @@ def main(
     """Main entry point for accessing contract & writing pool info"""
     # pylint: disable=too-many-locals
     # get web3 provider
-    web3_container: Web3 = contract_interface.setup_web3(ethereum_node)
+    web3: Web3 = contract_interface.setup_web3(ethereum_node)
     # send a request to the local server to fetch the deployed contract addresses and
     # load the deployed Hyperdrive contract addresses from the server response
-    state_hyperdrive_contract = contract_interface.get_hyperdrive_contract(
-        state_abi_file_path, contracts_url, web3_container
-    )
+    state_hyperdrive_contract = contract_interface.get_hyperdrive_contract(state_abi_file_path, contracts_url, web3)
     transactions_hyperdrive_contract = contract_interface.get_hyperdrive_contract(
-        transactions_abi_file_path, contracts_url, web3_container
+        transactions_abi_file_path, contracts_url, web3
     )
     # get pool config from hyperdrive contract
     config_file = os.path.join(save_dir, "hyperdrive_config.json")
     contract_interface.hyperdrive_config_to_json(config_file, state_hyperdrive_contract)
     # write the initial pool info
     block_number: BlockNumber = BlockNumber(start_block)
-    latest_block_number = web3_container.eth.get_block_number()
+    latest_block_number = web3.eth.get_block_number()
     lookback_block_limit = BlockNumber(lookback_block_limit)
     if (latest_block_number - block_number) > lookback_block_limit:
         block_number = BlockNumber(latest_block_number - lookback_block_limit)
@@ -50,9 +48,7 @@ def main(
 
     pool_info = []
 
-    block_pool_info: dict = contract_interface.get_block_pool_info(
-        web3_container, state_hyperdrive_contract, block_number
-    )
+    block_pool_info: dict = contract_interface.get_block_pool_info(web3, state_hyperdrive_contract, block_number)
     pool_info.append(block_pool_info)
     pool_info_file = os.path.join(save_dir, "hyperdrive_pool_info.json")
     transaction_info_file = os.path.join(save_dir, "hyperdrive_transactions.json")
@@ -62,7 +58,7 @@ def main(
     # monitor for new blocks & add pool info per block
     logging.info("Monitoring for pool info updates...")
     while True:
-        latest_block_number = web3_container.eth.get_block_number()
+        latest_block_number = web3.eth.get_block_number()
         # if we are on a new block
         if latest_block_number > block_number:
             # Backfilling for blocks that need updating
@@ -84,7 +80,7 @@ def main(
                 while True:
                     try:
                         block_pool_info = contract_interface.get_block_pool_info(
-                            web3_container, state_hyperdrive_contract, block_number
+                            web3, state_hyperdrive_contract, block_number
                         )
                         break
                     except ValueError:
@@ -95,7 +91,7 @@ def main(
                 if block_pool_info:
                     pool_info.append(block_pool_info)
                 block_transactions = contract_interface.fetch_transactions_for_block(
-                    web3_container, transactions_hyperdrive_contract, block_number
+                    web3, transactions_hyperdrive_contract, block_number
                 )
                 if block_transactions:
                     transaction_info.extend(block_transactions)

--- a/elfpy/data/contract_interface.py
+++ b/elfpy/data/contract_interface.py
@@ -30,14 +30,14 @@ class TestAccount:
         self.account: LocalAccount = Account().create(extra_entropy=extra_entropy)
 
     @property
-    def balance(self, funding_contract: Contract) -> int:
-        """Return the balance of the account"""
-        return funding_contract.functions.balanceOf(self.address).call()
-
-    @property
     def address(self) -> str:
         """Return the address of the account"""
         return self.account.address
+
+    @property
+    def balance(self, funding_contract: Contract) -> int:
+        """Return the balance of the account"""
+        return funding_contract.functions.balanceOf(self.address).call()
 
 
 @attr.s

--- a/elfpy/data/contract_interface.py
+++ b/elfpy/data/contract_interface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from typing import Any
 
@@ -30,6 +31,12 @@ class HyperdriveAddressesJson:
     base_token: str = attr.ib()
     mock_hyperdrive: str = attr.ib()
     mock_hyperdrive_math: str = attr.ib()
+
+
+def camel_to_snake(camel_string: str) -> str:
+    """Convert camelCase to snake_case"""
+    snake_string = re.sub(r"(?<!^)(?=[A-Z])", "_", camel_string)
+    return snake_string.lower()
 
 
 def fetch_addresses(contracts_url: str) -> HyperdriveAddressesJson:

--- a/elfpy/data/contract_interface.py
+++ b/elfpy/data/contract_interface.py
@@ -208,8 +208,21 @@ def save_config(config, file_path):
         toml.dump(config, file)
 
 
-def setup_web3(ethereum_node: URI | str) -> Web3:
-    """Create the Web3 provider and inject a geth Proof of Authority (poa) middleware."""
-    web3 = Web3(Web3.HTTPProvider(ethereum_node))
+def initialize_web3_with_http_provider(ethereum_node: URI | str, request_kwargs: dict | None = None) -> Web3:
+    """Initialize a Web3 instance using an HTTP provider
+    and inject a geth Proof of Authority (poa) middleware.
+    Arguments
+    ---------
+    ethereum_node: URI | str
+        Address of the http provider
+    request_kwargs: dict
+        The HTTPProvider uses the python requests library for making requests.
+        If you would like to modify how requests are made,
+        you can use the request_kwargs to do so.
+    """
+    if request_kwargs is None:
+        request_kwargs = {}
+    provider = Web3.HTTPProvider(ethereum_node, request_kwargs)
+    web3 = Web3(provider)
     web3.middleware_onion.inject(geth_poa.geth_poa_middleware, layer=0)
     return web3

--- a/elfpy/data/contract_interface.py
+++ b/elfpy/data/contract_interface.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 import time
-from typing import Any
+from typing import Any, Sequence
 
 import attr
 import requests

--- a/elfpy/data/contract_interface.py
+++ b/elfpy/data/contract_interface.py
@@ -25,6 +25,10 @@ from web3.types import ABI, ABIEvent, BlockData, EventData, LogReceipt, TxReceip
 class TestAccount:
     """Web3 account that has helper functions & associated funding source"""
 
+    # TODO: We should be adding more methods to this class.
+    # If not, we can delete it at the end of the refactor.
+    # pylint: disable=too-few-public-methods
+
     def __init__(self, extra_entropy: str = "TEST ACCOUNT"):
         """Initialize an account"""
         self.account: LocalAccount = Account().create(extra_entropy=extra_entropy)

--- a/elfpy/data/contract_interface.py
+++ b/elfpy/data/contract_interface.py
@@ -103,7 +103,6 @@ def fetch_and_decode_logs(web3: Web3, contract: Contract, tx_receipt: TxReceipt)
         for log in tx_receipt["logs"]:
             event_data, event = get_event_object(web3, contract, log, tx_receipt)
             if event_data and event:
-                # TODO: For some reason it thinks `log` is `str` instead of `EventData`
                 formatted_log = dict(event_data)
                 formatted_log["event"] = event.get("name")
                 formatted_log["args"] = dict(event_data["args"])

--- a/elfpy/data/contract_interface.py
+++ b/elfpy/data/contract_interface.py
@@ -69,7 +69,7 @@ def camel_to_snake(camel_string: str) -> str:
     return snake_string.lower()
 
 
-def collect_files(folder_path: str, extension: str = ".json") -> list[dict]:
+def collect_files(folder_path: str, extension: str = ".json") -> list[str]:
     """Load all files with the given extension into a list"""
     collected_files = []
     for root, _, files in os.walk(folder_path):
@@ -223,20 +223,6 @@ def initialize_web3_with_http_provider(ethereum_node: URI | str, request_kwargs:
     web3 = Web3(provider)
     web3.middleware_onion.inject(geth_poa.geth_poa_middleware, layer=0)
     return web3
-
-
-def deploy_contract(web3: Web3, contract_interface: dict) -> TxReceipt:
-    """Deploy contract to an address"""
-    tx_hash = (
-        web3.eth.contract(
-            abi=contract_interface["abi"],
-            bytecode=contract_interface["bin"],
-        )
-        .constructor()
-        .transact()
-    )
-    deploy_address: TxReceipt = web3.eth.get_transaction_receipt(tx_hash)["contractAddress"]
-    return deploy_address
 
 
 def fetch_address_from_url(contracts_url: str) -> HyperdriveAddressesJson:

--- a/elfpy/data/contract_interface.py
+++ b/elfpy/data/contract_interface.py
@@ -226,3 +226,11 @@ def initialize_web3_with_http_provider(ethereum_node: URI | str, request_kwargs:
     web3 = Web3(provider)
     web3.middleware_onion.inject(geth_poa.geth_poa_middleware, layer=0)
     return web3
+
+
+def get_hyperdrive_config(hyperdrive_contract: Contract) -> dict:
+    """Get the hyperdrive config from a deployed hyperdrive contract."""
+    hyperdrive_config: dict = get_smart_contract_read_call(hyperdrive_contract, "getPoolConfig")
+    hyperdrive_config["invScaledTimeStretch"] = 1 / (hyperdrive_config["timeStretch"] / 1e18)
+    hyperdrive_config["termLength"] = hyperdrive_config["positionDuration"] / 60 / 60 / 24  # in days
+    return hyperdrive_config

--- a/elfpy/data/contract_interface.py
+++ b/elfpy/data/contract_interface.py
@@ -166,13 +166,6 @@ def get_smart_contract_read_call(contract: Contract, function_name: str, **funct
     return function_return_dict
 
 
-def load_abi(file_path):
-    """Load the Application Binary Interface (ABI) from a JSON file"""
-    with open(file_path, mode="r", encoding="UTF-8") as file:
-        data = json.load(file)
-    return data["abi"]
-
-
 def recursive_dict_conversion(obj):
     """Recursively converts a dictionary to convert objects to hex values"""
     if isinstance(obj, HexBytes):
@@ -182,12 +175,6 @@ def recursive_dict_conversion(obj):
     if hasattr(obj, "items"):
         return {key: recursive_dict_conversion(value) for key, value in obj.items()}
     return obj
-
-
-def save_config(config, file_path):
-    """Saves the config file in TOML format"""
-    with open(file_path, "w", encoding="UTF-8") as file:
-        toml.dump(config, file)
 
 
 def initialize_web3_with_http_provider(ethereum_node: URI | str, request_kwargs: dict | None = None) -> Web3:
@@ -210,7 +197,7 @@ def initialize_web3_with_http_provider(ethereum_node: URI | str, request_kwargs:
     return web3
 
 
-def fetch_addresses(contracts_url: str) -> HyperdriveAddressesJson:
+def fetch_address_from_url(contracts_url: str) -> HyperdriveAddressesJson:
     """Fetch addresses for deployed contracts in the Hyperdrive system."""
     attempt_num = 0
     response = None
@@ -227,15 +214,13 @@ def fetch_addresses(contracts_url: str) -> HyperdriveAddressesJson:
     if response.status_code != 200:
         raise ConnectionError(f"Request failed with status code {response.status_code} @ {time.ctime()}")
     addresses_json = response.json()
-    addresses = HyperdriveAddressesJson(
-        **{ape_utils.camel_to_snake(key): value for key, value in addresses_json.items()}
-    )
+    addresses = HyperdriveAddressesJson(**{camel_to_snake(key): value for key, value in addresses_json.items()})
     return addresses
 
 
 def get_hyperdrive_contract(abi_file_path: str, contracts_url: str, web3: Web3) -> Contract:
     """Get the hyperdrive contract for a given abi"""
-    addresses = fetch_addresses(contracts_url)
+    addresses = fetch_address_from_url(contracts_url)
     # Load the ABI from the JSON file
     with open(abi_file_path, "r", encoding="UTF-8") as file:
         state_abi = json.load(file)["abi"]

--- a/elfpy/data/contract_interface.py
+++ b/elfpy/data/contract_interface.py
@@ -33,7 +33,7 @@ class FundableAccount:
     ):
         """Initialize an account"""
         self.funding_contract: Contract = funding_contract
-        self.account: LocalAccount = Account.create(extra_entropy=extra_entropy)
+        self.account: LocalAccount = Account().create(extra_entropy=extra_entropy)
         self.fund_account(initial_supply)
 
     def fund_account(self, amount: int) -> HexBytes:
@@ -207,8 +207,8 @@ def recursive_dict_conversion(obj):
 
 
 def initialize_web3_with_http_provider(ethereum_node: URI | str, request_kwargs: dict | None = None) -> Web3:
-    """Initialize a Web3 instance using an HTTP provider
-    and inject a geth Proof of Authority (poa) middleware.
+    """Initialize a Web3 instance using an HTTP provider and inject a geth Proof of Authority (poa) middleware.
+
     Arguments
     ---------
     ethereum_node: URI | str

--- a/elfpy/data/contract_interface.py
+++ b/elfpy/data/contract_interface.py
@@ -34,11 +34,6 @@ class TestAccount:
         """Return the address of the account"""
         return self.account.address
 
-    @property
-    def balance(self, funding_contract: Contract) -> int:
-        """Return the balance of the account"""
-        return funding_contract.functions.balanceOf(self.address).call()
-
 
 @attr.s
 class HyperdriveAddressesJson:
@@ -49,6 +44,11 @@ class HyperdriveAddressesJson:
     base_token: str = attr.ib()
     mock_hyperdrive: str = attr.ib()
     mock_hyperdrive_math: str = attr.ib()
+
+
+def get_account_balance_for_contract(funding_contract: Contract, account_address: str) -> int:
+    """Return the balance of the account"""
+    return funding_contract.functions.balanceOf(account_address).call()
 
 
 def fund_account(funding_contract: Contract, account_address: str, amount: int) -> HexBytes:

--- a/elfpy/utils/apeworx_integrations.py
+++ b/elfpy/utils/apeworx_integrations.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 from collections import namedtuple
 from dataclasses import dataclass
 from pathlib import Path

--- a/elfpy/utils/apeworx_integrations.py
+++ b/elfpy/utils/apeworx_integrations.py
@@ -136,9 +136,9 @@ def get_hyperdrive_config(hyperdrive_instance) -> dict:
     """
     hyperdrive_config: dict = hyperdrive_instance.getPoolConfig().__dict__
     hyperdrive_config["timeStretch"] = 1 / (hyperdrive_config["timeStretch"] / 1e18)
+    hyperdrive_config["term_length"] = hyperdrive_config["positionDuration"] / 60 / 60 / 24  # in days
     logging.info("Hyperdrive config deployed at %s: ", hyperdrive_instance.address)
     logging.info("Hyperdrive config: %s", hyperdrive_config)
-    hyperdrive_config["term_length"] = hyperdrive_config["positionDuration"] / 60 / 60 / 24  # in days
     return hyperdrive_config
 
 


### PR DESCRIPTION
This PR continues the process of getting rid of ape from our dependencies and using core web3py utilities. The primary contribution is to create a new `testAgent` class. This object acts as a test agent that can arbitrarily approve & tokens (e.g. minted ERC20 base tokens) into it's supply.


The following code demonstrates how to initialize a fundableAgent & add money.

```
from web3.contract.contract import Contract

from elfpy.data import contract_interface as ci

ETHEREUM_NODE = "http://localhost:8545"
CONTRACTS_URL = "http://localhost:80/addresses.json"
BUILD_FOLDER = "./hyperdrive_solidity/.build"

# Generate the contract object
web3 = ci.initialize_web3_with_http_provider(ETHEREUM_NODE)
hyperdrive_abis = ci.load_all_abis(BUILD_FOLDER)
addresses = ci.fetch_address_from_url(CONTRACTS_URL)
initial_supply = int(10e18)
initial_apr = int(0.1e18)
extra_entropy = "BEEP BOOP"

base_contract: Contract = web3.eth.contract(abi=hyperdrive_abis["ERC20Mintable"], address=addresses.base_token)
print(f"{base_contract.functions.totalSupply().call()=}")

test_account = ci.TestAccount(extra_entropy)
print(f"{test_account.address=}")
print(f"{ci.get_account_balance_for_contract(funding_contract, test_account.address)=}")

ci.fund_account(funding_contract, test_account.address, initial_supply)
print(f"{test_account.address=}")
print(f"{ci.get_account_balance_for_contract(funding_contract, test_account.address)=}")

ci.fund_account(funding_contract, test_account.address, int(10e18))
print(f"{ci.get_account_balance_for_contract(funding_contract, test_account.address)=}")

print(f"{base_contract.functions.totalSupply().call()=}")

hyperdrive_contract: Contract = web3.eth.contract(
    abi=hyperdrive_abis["MockHyperdriveTestnet"],
    address=addresses.mock_hyperdrive,
)
```

Follow-up PRs will continue to migrate functionality over to the web3py, then add tests, then remove apeworx from the repo.