### PR TITLE
Using binary of psycopg2 for installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ with-dependencies = [
 ]
 
 postgres = [
-    "psycopg2",
+    "psycopg2-binary",
     "sqlalchemy",
 ]
 


### PR DESCRIPTION
Removes any additional steps to install postgres requirements