### PR TITLE
Add docker script to build and push to ghcr.io

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -20,3 +20,23 @@ elf-sims      latest    fd84351979d7   21 minutes ago   2.04GB
 
 This image receives the `elf-sims` tag and can be reference with`image: elf-sims:latest`,
 for instance if you're using Docker Compose.
+
+To build a local image and push it to ghcr.io, make sure you have Docker installed and running, then use:
+
+```bash
+>> ./scripts/build_and_push_docker_iamge.sh
+Tag pushed to ghcr.io/delvtech/elf-simulations/dcdefc6153fc
+Run the following command to retrieve the image:
+docker image pull ghcr.io/delvtech/elf-simulations/dcdefc6153fc
+```
+
+If you you get a 401 error, you'll need to make a GH Personal Access Token with write accesss.
+
+You can optionally provide a tag
+
+```bash
+>> ./scripts/build_and_push_docker_iamge.sh matt-latest
+Tag pushed to ghcr.io/delvtech/elf-simulations/matt-latest
+Run the following command to retrieve the image:
+docker image pull ghcr.io/delvtech/elf-simulations/matt-latest
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . ./
 
 # install elfpy
 RUN python -m pip install --no-cache-dir --upgrade pip
-RUN python -m pip install --no-cache-dir -e ."[with-dependencies,docs]"
+RUN python -m pip install --no-cache-dir -e ."[with-dependencies]"
 RUN ape plugins install .
 
 # copy hyperdrive contracts from migrations image

--- a/scripts/build_and_push_docker_image.sh
+++ b/scripts/build_and_push_docker_image.sh
@@ -1,29 +1,28 @@
 #!/bin/bash
 
-TAG=""
+TAG="default"
 
 if [ $# -eq 0 ]; then
-  echo "Using Image ID as the tag for the image."
+  echo "Using 'default' as the tag for the image."
 else
   TAG="$1"
   echo "Using $TAG as the tag for the image."
 fi
 
-TAG_OPTION=""
-if [[ -n $TAG ]]; then
-    TAG_OPTION="-t $TAG"
-fi
+echo "Tag: $TAG"
 
-IMAGE_ID=$(docker build --no-cache $TAG_OPTION -f Dockerfile ../ | tail -n 1 | awk '{ print $NF }')
+docker build --no-cache -t $TAG -f Dockerfile .
+IMAGE_ID=$(docker image ls -q | awk 'NR==1{print}')
 echo "Image Id: $IMAGE_ID"
 
-if [[ -n $TAG ]]; then
+if [[ "$TAG" == "default" ]]; then
     TAG=$IMAGE_ID
 fi
+echo "Tag: $TAG"
 
 docker tag $IMAGE_ID ghcr.io/delvtech/elf-simulations/$TAG
 docker image push ghcr.io/delvtech/elf-simulations/$TAG
 
-echo "Tag pushed to ghcr.io/delvtech/elf-simulations$TAG"
+echo "Tag pushed to ghcr.io/delvtech/elf-simulations/$TAG"
 echo "Run the following command to retrieve the image:"
-echo "docker image pull ghcr.io/delvtech/elf-simulations$TAG"
+echo "docker image pull ghcr.io/delvtech/elf-simulations/$TAG"

--- a/scripts/build_and_push_docker_image.sh
+++ b/scripts/build_and_push_docker_image.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+TAG=""
+
+if [ $# -eq 0 ]; then
+  echo "Using Image ID as the tag for the image."
+else
+  TAG="$1"
+  echo "Using $TAG as the tag for the image."
+fi
+
+TAG_OPTION=""
+if [[ -n $TAG ]]; then
+    TAG_OPTION="-t $TAG"
+fi
+
+IMAGE_ID=$(docker build --no-cache $TAG_OPTION -f Dockerfile ../ | tail -n 1 | awk '{ print $NF }')
+echo "Image Id: $IMAGE_ID"
+
+if [[ -n $TAG ]]; then
+    TAG=$IMAGE_ID
+fi
+
+docker tag $IMAGE_ID ghcr.io/delvtech/elf-simulations/$TAG
+docker image push ghcr.io/delvtech/elf-simulations/$TAG
+
+echo "Tag pushed to ghcr.io/delvtech/elf-simulations$TAG"
+echo "Run the following command to retrieve the image:"
+echo "docker image pull ghcr.io/delvtech/elf-simulations$TAG"


### PR DESCRIPTION
Adds a helper script to build and push a docker image to ghcr.io.  This aids with the workflow of making changes locally to create custom bot scripts, uploading an image to ghcr.io and pulling to down on an ec2 instance to run in the cloud.
