### PR TITLE
Revert "Reverting back to using GITHUB_TOKEN (#602)"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,14 +21,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          token: ${{ secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN}}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_GITHUB_COM_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,9 @@ jobs:
       packages: write
     steps:
       - name: Check GitHub rate limit at start
-        run: |
-          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+        uses: wakamex/rate-limit-action@master
+        with:
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN}}
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -56,5 +57,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Check GitHub rate limit at end
-        run: |
-          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+        uses: wakamex/rate-limit-action@master
+        with:
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Check GitHub rate limit at start
+        run: |
+          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+
       - name: Check out code
         uses: actions/checkout@v3
         with:
@@ -50,3 +54,7 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Check GitHub rate limit at end
+        run: |
+          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check GitHub rate limit at start
-        run: |
-          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+        uses: wakamex/rate-limit-action@master
+        with:
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN}}
 
       - uses: actions/checkout@v3
         with:
@@ -40,5 +41,6 @@ jobs:
         run: python -m pylint $(git ls-files '*.py')
 
       - name: Check GitHub rate limit at end
-        run: |
-          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+        uses: wakamex/rate-limit-action@master
+        with:
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN}}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Check GitHub rate limit at start
+        run: |
+          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_GITHUB_COM_TOKEN }}
@@ -34,3 +38,7 @@ jobs:
 
       - name: Run pylint
         run: python -m pylint $(git ls-files '*.py')
+
+      - name: Check GitHub rate limit at end
+        run: |
+          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: "pip"
-          token: ${{ secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN }}
       - run: |
           python -m pip install --upgrade pip
           python -m pip install .[with-dependencies]

--- a/.github/workflows/ratelimit.yml
+++ b/.github/workflows/ratelimit.yml
@@ -5,8 +5,6 @@ on:
     workflows: ["lint"]
     types:
       - completed
-  push:
-    branches: [ revert_revert ]
 
 jobs:
   check-rate-limit:

--- a/.github/workflows/ratelimit.yml
+++ b/.github/workflows/ratelimit.yml
@@ -1,0 +1,20 @@
+name: Check Rate Limit
+
+on:
+  workflow_run:
+    workflows: ["lint"]
+    types:
+      - completed
+
+jobs:
+  check-rate-limit:
+    runs-on: ubuntu-latest
+    steps:
+      - id: calc
+        uses: wakamex/rate-limit-action@master
+        with:
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN }}
+          sha: ${{ github.event.workflow_run.head_sha }}
+          post_comment: true
+    outputs:
+      remaining: ${{ steps.calc.outputs.remaining }}

--- a/.github/workflows/ratelimit.yml
+++ b/.github/workflows/ratelimit.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["lint"]
     types:
       - completed
+  push:
+    branches: [ revert_revert ]
 
 jobs:
   check-rate-limit:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,6 +11,10 @@ jobs:
     name: static
     runs-on: ubuntu-latest
     steps:
+      - name: Check GitHub rate limit at start
+        run: |
+          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_GITHUB_COM_TOKEN }}
@@ -28,3 +32,7 @@ jobs:
 
       - name: Analysing code with pyright
         run: python -m pyright $(git ls-files '*.py')
+
+      - name: Check GitHub rate limit at end
+        run: |
+          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: "pip"
-          token: ${{ secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN }}
       - run: |
           python -m pip install --upgrade pip
           python -m pip install .[with-dependencies]

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check GitHub rate limit at start
-        run: |
-          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+        uses: wakamex/rate-limit-action@master
+        with:
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN}}
 
       - uses: actions/checkout@v3
         with:
@@ -34,5 +35,6 @@ jobs:
         run: python -m pyright $(git ls-files '*.py')
 
       - name: Check GitHub rate limit at end
-        run: |
-          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+        uses: wakamex/rate-limit-action@master
+        with:
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check GitHub rate limit at start
-        run: |
-          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+        uses: wakamex/rate-limit-action@master
+        with:
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN}}
 
       - uses: actions/checkout@v3
         with:
@@ -69,6 +70,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Check GitHub rate limit at end
-        run: |
-          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
-  
+        uses: wakamex/rate-limit-action@master
+        with:
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
+      - name: Check GitHub rate limit at start
+        run: |
+          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_GITHUB_COM_TOKEN }}
@@ -63,3 +67,8 @@ jobs:
           # A warning is thrown here unnecessarily.  tracking issue here:
           # https://github.com/github/vscode-github-actions/issues/222
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Check GitHub rate limit at end
+        run: |
+          curl -sI -H "Authorization: token ${{ secrets.GH_GITHUB_COM_TOKEN }}" https://api.github.com/rate_limit | grep X-Ratelimit-Remaining
+  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN }}
 
       - name: install node
         uses: actions/setup-node@v3
@@ -39,7 +39,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
-          token: ${{ secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GH_GITHUB_COM_TOKEN }}
       - run: |
           python -m pip install --upgrade pip
           python -m pip install .[with-dependencies,postgres]


### PR DESCRIPTION
track github rate limit using custom token on every workflow. shouldn't get random rate limit errors anymore.
- two steps added to each workflow .yml that prints to the action log the rate limit at the start and end
- a separate ratelimit.yml action triggers at the completion of the lint workflow (the slowest)
- this flow is parameterized to comment on the associated PR issue with the remaining rate limit
- this can be turned off by removing the `post_comment: true` parameter, at which point the `sha` parameter is no longer needed (it's only used to look up the associated PR based on the SHA of the triggerring workflow)
- each of these steps uses this github action stored in my own repo: https://github.com/wakamex/rate-limit-action/