### PR TITLE
Add a crash report issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/crash-report.md
+++ b/.github/ISSUE_TEMPLATE/crash-report.md
@@ -1,0 +1,68 @@
+---
+name: Crash Report
+about: A template for creating crash reports and bug findings.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Crash Report
+
+
+### Description
+
+[Provide a clear and concise description of the bug or crash you encountered.]
+
+
+### Expected Behavior
+
+[Describe what you expected to happen.]
+
+
+### Actual Behavior
+
+[Describe what actually happened.]
+
+
+### Steps to Reproduce
+
+[Provide a step-by-step guide to reproduce the issue.]
+
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+...
+
+
+### Possible Solution
+
+[If you have any ideas or suggestions on how to fix the issue, you can mention them here.]
+
+
+### Screenshots or Error Messages
+
+[If applicable, include any relevant screenshots or error messages that you received.]
+
+
+### Logs or Stack Traces
+
+[If available, include any relevant logs or stack traces related to the issue.]
+
+
+### Environment
+
+- Hyperdrive Version: [Specify the release version, i.e. 0.0.4.]
+- Elf Simulations Version: [Specify the release version, i.e. 0.0.4.]
+- Infra Version: [Specify the release version, i.e. 0.0.4.]
+- Additional Information: [Include any additional information about your environment that may be relevant, such as device type, software versions, etc.]
+
+
+### Related Issues
+
+[If there are any related issues or pull requests, reference them here.]
+
+
+### Any Other Information
+
+[Add any other information that you think might be helpful for troubleshooting the bug or crash.]


### PR DESCRIPTION
This is mostly for finding bugs with the hyperdrive protocol.  We can also use this if we have bugs with the simulation repo as well.