### PR TITLE
Filter PNL in streamlit dashboard

### DIFF
--- a/elfpy/data/postgres.py
+++ b/elfpy/data/postgres.py
@@ -385,7 +385,6 @@ def get_agents(session: Session, start_block: int | None = None, end_block: int 
 
     if query is None:
         return []
-    # TODO test return when empty table
     query = query.distinct()
 
     results = pd.read_sql(query.statement, con=session.connection())

--- a/elfpy/data/postgres.py
+++ b/elfpy/data/postgres.py
@@ -369,6 +369,30 @@ def get_current_wallet_info(
     return current_wallet_info
 
 
+def get_agents(session: Session, start_block: int | None = None, end_block: int | None = None) -> list[str]:
+    """Gets the list of all agents from the WalletInfo table"""
+    query = session.query(WalletInfo.walletAddress)
+    # Support for negative indices
+    if (start_block is not None) and (start_block < 0):
+        start_block = _get_latest_block_number_wallet_info(session) + start_block + 1
+    if (end_block is not None) and (end_block < 0):
+        end_block = _get_latest_block_number_wallet_info(session) + end_block + 1
+
+    if start_block is not None:
+        query = query.filter(WalletInfo.blockNumber >= start_block)
+    if end_block is not None:
+        query = query.filter(WalletInfo.blockNumber < end_block)
+
+    if query is None:
+        return []
+    # TODO test return when empty table
+    query = query.distinct()
+
+    results = pd.read_sql(query.statement, con=session.connection())
+
+    return results["walletAddress"].to_list()
+
+
 def get_latest_block_number(session: Session) -> int:
     """Gets the latest block number based on the pool info table in the db
     Arguments

--- a/examples/hackweek_demo/extract_data_logs.py
+++ b/examples/hackweek_demo/extract_data_logs.py
@@ -108,4 +108,6 @@ def get_combined_data(txn_data, pool_info_data):
     trade_data["timestamp"] = trade_data["block_timestamp"]
     trade_data["block_timestamp"] = trade_data["block_timestamp"].astype(int)
 
+    trade_data = trade_data.sort_values("block_timestamp")
+
     return trade_data

--- a/examples/hackweek_demo/run_demo.py
+++ b/examples/hackweek_demo/run_demo.py
@@ -20,9 +20,6 @@ from elfpy.data import postgres
 # None to view all
 view_window = None
 
-# set up streamlit
-# creating a single-element container
-placeholder = st.empty()
 
 # %%
 # near real-time / live feed simulation
@@ -30,12 +27,7 @@ placeholder = st.empty()
 ## Get transactions from data
 
 
-def get_ticker(data):
-    """Given transaction data, return a subset of the dataframe"""
-    # Return reverse of methods to put most recent transactions at the top
-    out = data[["blockNumber", "input_method"]].set_index("blockNumber").iloc[::-1]
-    return out
-
+# TODO should these all be seperate figures instead of one figure?
 
 fig = mpf.figure(style="mike", figsize=(15, 15))  # type: ignore
 ax_ohlcv = fig.add_subplot(2, 2, 1)
@@ -56,11 +48,39 @@ else:
 # pool config data is static, so just read once
 config_data = postgres.get_pool_config(session)
 
+# Set up agent selection state list outside of live updates
+st.session_state.options = []
+
+
+def get_ticker(data):
+    """Given transaction data, return a subset of the dataframe"""
+    # Return reverse of methods to put most recent transactions at the top
+    out = data[["blockNumber", "input_method"]].set_index("blockNumber").iloc[::-1]
+    return out
+
+
+agent_list = postgres.get_agents(session, start_block=start_block)
+
+filter_agents = st.multiselect("PNL Agents", agent_list, key="agent_select")
+
+
+# set up streamlit
+input_placeholder = st.empty()
+# creating a single-element container
+main_placeholder = st.empty()
+# creating a single-element sidebar
+sidebar_placeholder = st.sidebar.empty()
+
+
 while True:
     txn_data = postgres.get_transactions(session, start_block=start_block)
     pool_info_data = postgres.get_pool_info(session, start_block=start_block)
 
     combined_data = get_combined_data(txn_data, pool_info_data)
+
+    if len(combined_data) == 0:
+        time.sleep(0.1)
+        continue
 
     ohlcv = calc_ohlcv(combined_data, freq="5T")
 
@@ -68,7 +88,7 @@ while True:
 
     (fixed_rate_x, fixed_rate_y) = calc_fixed_rate(combined_data)
 
-    pnl_x, pnl_y = calculate_pnl(combined_data)
+    pnl_x, pnl_y = calculate_pnl(combined_data, filter_agents)
 
     # Plot reserve levels (share and bond reserves, in poolinfo)
 
@@ -76,24 +96,24 @@ while True:
 
     # Add ticker
 
-    with placeholder.container():
-        ticker_col, plots_col = st.columns([0.2, 1], gap="small")
-        with ticker_col:
-            st.dataframe(ticker.iloc[:100], height=900, width=170)
+    # Selection options for filtering agent, defined outside of update loop
+    # Session state gets updated inside loop
+    # with plots_col:
+    with sidebar_placeholder.container():
+        st.dataframe(ticker.iloc[:100], height=900, use_container_width=True)
 
-        with plots_col:
-            # Clears all axes
-            ax_ohlcv.clear()
-            ax_fixed_rate.clear()
-            ax_vol.clear()
-            ax_pnl.clear()
+    with main_placeholder.container():
+        # Clears all axes
+        ax_vol.clear()
+        ax_pnl.clear()
+        ax_ohlcv.clear()
+        ax_fixed_rate.clear()
 
-            # TODO add in volume
-            plot_ohlcv(ohlcv, ax_ohlcv, ax_vol)
-            plot_fixed_rate(fixed_rate_x, fixed_rate_y, ax_fixed_rate)
-            plot_pnl(pnl_x, pnl_y, ax_pnl)
+        plot_ohlcv(ohlcv, ax_ohlcv, ax_vol)
+        plot_fixed_rate(fixed_rate_x, fixed_rate_y, ax_fixed_rate)
+        plot_pnl(pnl_x, pnl_y, ax_pnl)
 
-            fig.autofmt_xdate()  # type: ignore
-            st.pyplot(fig=fig)  # type: ignore
+        fig.autofmt_xdate()  # type: ignore
+        st.pyplot(fig=fig)  # type: ignore
 
     time.sleep(0.1)

--- a/examples/hackweek_demo/run_demo.py
+++ b/examples/hackweek_demo/run_demo.py
@@ -64,8 +64,6 @@ agent_list = postgres.get_agents(session, start_block=start_block)
 filter_agents = st.multiselect("PNL Agents", agent_list, key="agent_select")
 
 
-# set up streamlit
-input_placeholder = st.empty()
 # creating a single-element container
 main_placeholder = st.empty()
 # creating a single-element sidebar

--- a/tests/data/test_wallet_info.py
+++ b/tests/data/test_wallet_info.py
@@ -142,3 +142,15 @@ class TestWalletInfoInterface:
         wallet_info_df = postgres.get_current_wallet_info(session).reset_index()
         assert wallet_info_df["tokenType"].equals(pd.Series(["BASE", "LP"], name="tokenType"))
         assert wallet_info_df["tokenValue"].equals(pd.Series([6.1, 5.1], name="tokenValue"))
+
+    def test_get_agents(self, session):
+        """Testing helper function to get current wallet values"""
+        wallet_info_1 = WalletInfo(blockNumber=0, walletAddress="addr_1")  # add your other columns here...
+        wallet_info_2 = WalletInfo(blockNumber=1, walletAddress="addr_1")  # add your other columns here...
+        wallet_info_3 = WalletInfo(blockNumber=2, walletAddress="addr_2")  # add your other columns here...
+        postgres.add_wallet_infos([wallet_info_1, wallet_info_2, wallet_info_3], session)
+
+        agents = postgres.get_agents(session)
+        assert len(agents) == 2
+        assert "addr_1" in agents
+        assert "addr_2" in agents


### PR DESCRIPTION
Adding an option to pick what agents to plot PNL for:

![image](https://github.com/delvtech/elf-simulations/assets/1431723/d43d197b-70b1-4101-bfb6-0034ae8711c6)

![image](https://github.com/delvtech/elf-simulations/assets/1431723/8771aa46-cf91-490e-ba1f-455d923d6c3b)

Currently, doing selection based on wallet addresses, but will eventually replace this with usernames (https://github.com/delvtech/elf-simulations/pull/663, https://github.com/delvtech/elf-simulations/issues/635)