### PR TITLE
Fix tests broken from fixedpointmath version update.

### DIFF
--- a/elfpy/markets/base/base_pricing_model.py
+++ b/elfpy/markets/base/base_pricing_model.py
@@ -221,6 +221,7 @@ class BasePricingModel(ABC):
         time_remaining: time.StretchedTime,
     ):
         """Applies a set of assertions to the input of a trading function."""
+        assert time_remaining.normalized_time <= 1
         assert quantity.amount >= elfpy.WEI, f"expected quantity.amount >= {elfpy.WEI}, not {quantity.amount}!"
         assert market_state.share_reserves >= FixedPoint(
             "0.0"

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -360,7 +360,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 time_remaining=time.StretchedTime(
                     days=FixedPoint("500.0"), time_stretch=FixedPoint("1.1"), normalizing_constant=FixedPoint("365.0")
                 ),
-                exception_type=(AssertionError),
+                exception_type=AssertionError,
             ),
             CalcInGivenOutFailureTestCase(  # test 11
                 # amount very high, can't make trade

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -360,7 +360,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 time_remaining=time.StretchedTime(
                     days=FixedPoint("500.0"), time_stretch=FixedPoint("1.1"), normalizing_constant=FixedPoint("365.0")
                 ),
-                exception_type=(AssertionError, fperrors.DivisionByZero),
+                exception_type=(AssertionError),
             ),
             CalcInGivenOutFailureTestCase(  # test 11
                 # amount very high, can't make trade

--- a/tests/pricing_models/test_calc_out_given_in.py
+++ b/tests/pricing_models/test_calc_out_given_in.py
@@ -1621,7 +1621,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 time_remaining=time.StretchedTime(
                     days=FixedPoint("500.0"), time_stretch=FixedPoint("1.0"), normalizing_constant=FixedPoint("365.0")
                 ),
-                exception_type=(AssertionError, fperrors.DivisionByZero),
+                exception_type=(AssertionError),
             ),
             CalcOutGivenInFailureTestCase(  # test 11
                 # amount very high, can't make trade

--- a/tests/pricing_models/test_calc_out_given_in.py
+++ b/tests/pricing_models/test_calc_out_given_in.py
@@ -1621,7 +1621,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 time_remaining=time.StretchedTime(
                     days=FixedPoint("500.0"), time_stretch=FixedPoint("1.0"), normalizing_constant=FixedPoint("365.0")
                 ),
-                exception_type=(AssertionError),
+                exception_type=AssertionError,
             ),
             CalcOutGivenInFailureTestCase(  # test 11
                 # amount very high, can't make trade


### PR DESCRIPTION
A couple tests pass now that used to have a DivisionByZero error now that we can handle negative numbers.  We still want to have the tests make sure we are limiting terms to less than a year so I added that assertion.  