### PR TITLE
Adding helper function to get all wallet info history

### DIFF
--- a/elfpy/data/postgres.py
+++ b/elfpy/data/postgres.py
@@ -376,21 +376,30 @@ def get_all_wallet_info(session: Session, start_block: int | None = None, end_bl
 
 
 def get_wallet_info_history(session: Session) -> dict[str, pd.DataFrame]:
-    """Gets the history of all wallet info over block time"""
+    """Gets the history of all wallet info over block time
+    Arguments
+    ---------
+    session: Session
+        The initialized session object
+
+    Returns
+    -------
+    dict[str, DataFrame]
+        A dictionary keyed by the wallet address, where the values is a DataFrame
+        where the index is the block number, and the columns is the number of each token the address has at that block number
+        plus a timestamp of the block number
+    """
+
     all_wallet_info = get_all_wallet_info(session)
     max_block = get_latest_block_number(session)
-
-    # Get the timestamp
     timestamp_lookup = get_pool_info(session)[["blockNumber", "timestamp"]].set_index("blockNumber")
 
     # Pivot tokenType to columns
     all_wallet_info = all_wallet_info.pivot(
         values="tokenValue", index=["blockNumber", "walletAddress"], columns=["tokenType"]
     ).reset_index()
-
     # Organize indices
     all_wallet_info = all_wallet_info.set_index(["walletAddress", "blockNumber"]).sort_index()
-
     # Fill NaNs with 0s (nonexistant tokens mean 0 tokens)
     all_wallet_info = all_wallet_info.fillna(0)
 

--- a/elfpy/data/postgres.py
+++ b/elfpy/data/postgres.py
@@ -386,8 +386,8 @@ def get_wallet_info_history(session: Session) -> dict[str, pd.DataFrame]:
     -------
     dict[str, DataFrame]
         A dictionary keyed by the wallet address, where the values is a DataFrame
-        where the index is the block number, and the columns is the number of each token the address has at that block number
-        plus a timestamp of the block number
+        where the index is the block number, and the columns is the number of each
+        token the address has at that block number plus a timestamp of the block number
     """
 
     all_wallet_info = get_all_wallet_info(session)


### PR DESCRIPTION
Helper function changes from a long wallet table to a pivoted table where index is block number, columns contains the token type, timestamp, and the sharePrice of the block.

```
                     BASE  LONG-1720828800          LP  SHORT-1720828800           timestamp  sharePrice
blockNumber                                                                                             
26           49256.647102       775.993865    0.000000          0.000000 2023-07-13 19:29:47    1.002446
27           49256.647102       775.993865    0.000000          0.000000 2023-07-13 19:29:48    1.002446
28           49256.647102       775.993865    0.000000          0.000000 2023-07-13 19:29:49    1.002446
29           49256.647102       775.993865    0.000000          0.000000 2023-07-13 19:29:50    1.002447
30           49256.647102       775.993865    0.000000          0.000000 2023-07-13 19:29:51    1.002447
...                   ...              ...         ...               ...                 ...         ...
545          40617.518873      8394.881810  745.273911       5080.333768 2023-07-13 19:38:26    1.003985
546          40617.518873      8394.881810  745.273911       5080.333768 2023-07-13 19:38:27    1.003985
547          40617.518873      8394.881810  745.273911       5080.333768 2023-07-13 19:38:28    1.003985
548          40617.518873      8394.881810  745.273911       5080.333768 2023-07-13 19:38:29    1.003986
549          40617.518873      8394.881810  745.273911       5080.333768 2023-07-13 19:38:30    1.004001

[524 rows x 6 columns]
```