### PR TITLE
fix requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ with-dependencies = [
     "pytest",
     "python-dotenv",
     "scipy",
-    "tomli",
     "typing_extensions==4.5.0",
     # bot dependencies
     "web3",
@@ -59,15 +58,15 @@ with-dependencies = [
 
 docs = [
     "tomli>=2.0.1",
-    "sphinx>=5.3",
+    "sphinx>=6",
     "sphinx_autodoc_typehints>=1.21.8",
     "sphinx-autoapi>=2.0.1",
-    "myst-parser>=0.18.1",
+    "myst-parser>=2.0.0",
     "numpydoc>=1.5.0",
     "sphinxcontrib-napoleon>=0.7",
-    "autodocsumm>=0.2.10",
+    "autodocsumm>=0.2.11",
     "nbsphinx>=0.8.12",
-    "sphinx-rtd-theme>=1.1.1",
+    "sphinx-rtd-theme>=1.2.2",
     # urllib3 v2 requires OpenSSL v1.1.1+, but Vercel uses v1.0.2
     "urllib3<2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 ]
 description = "Experiment management and market simulators by Delv"
 readme = "README.md"
-requires-python = "3.10"
+requires-python = ">=3.10, <3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache License 2.0",

--- a/scripts/vercel-install.sh
+++ b/scripts/vercel-install.sh
@@ -1,5 +1,13 @@
 python3 --version
 which python3
 python3 -m ensurepip
-python3 -m pip install --upgrade pip
-python3 -m pip install .[docs]
+python3 -m pip install --upgrade pip pip-tools
+
+# install only dependencies using this one weird trick (https://github.com/pypa/pip/issues/11440#issuecomment-1638573638)
+# the elf-simulations package is not required to builds docs and vercel does not support python 3.10 as of July 18, 2023
+PYTHON=python3
+EXTRAS=docs
+PIPFLAGS="--no-warn-conflicts"
+$PYTHON -m pip install pip-tools
+$PYTHON -m piptools compile --extra=$EXTRAS -o - pyproject.toml |
+$PYTHON -m pip install -r /dev/stdin $PIPFLAGS


### PR DESCRIPTION
according to [python.org](https://packaging.python.org/en/latest/specifications/core-metadata/#requires-python) have to match [version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/) most recently defined by [PEP 440](https://peps.python.org/pep-0440/)
[examples](https://peps.python.org/pep-0440/#examples):
>    ~=3.1: version 3.1 or later, but not version 4.0 or later.
    ~=3.1.2: version 3.1.2 or later, but not version 3.2.0 or later.
    ~=3.1a1: version 3.1a1 or later, but not version 4.0 or later.
    == 3.1: specifically version 3.1 (or 3.1.0), excludes all pre-releases, post releases, developmental releases and any 3.1.x maintenance releases.
    == 3.1.*: any version that starts with 3.1. Equivalent to the ~=3.1.0 compatible release clause.
    ~=3.1.0, != 3.1.3: version 3.1.0 or later, but not version 3.1.3 and not version 3.2.0 or later.

I was alerted to this by [ruff](https://github.com/astral-sh/ruff) which was correctly throwing an error:
```
error: TOML parse error at line 20, column 19
   |
20 | requires-python = "3.10"
   |                   ^^^^^^
Failed to parse version:
3.10
^^^^
```

PS: also noticed pip would throw a warning:
```
pip install -e .
Obtaining file:///code/elfpy
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
WARNING: Package 'elfpy' has an invalid Requires-Python: Invalid specifier: '3.10'
```