### PR TITLE
Enforce docstring linting!

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,9 +36,19 @@ jobs:
       - name: Run black
         run: python -m black --check --diff .
 
-      - name: Run pylint
+      - name: Get changed Python files
+        id: changed_files
         run: |
-          pylint --rcfile=.pylintrc $(git diff --name-only origin/main...HEAD | grep '.py$')
+          echo "::set-output name=files::$(git diff --name-only origin/main...HEAD | grep '.py$')"
+
+      - name: Run Pylint on changed files
+        run: |
+          files="${{ steps.changed_files.outputs.files }}"
+          if [ -n "$files" ]; then
+            pylint --rcfile=.pylintrc $files
+          else
+            echo "No Python files have changed."
+          fi
 
       - name: Check GitHub rate limit at end
         uses: wakamex/rate-limit-action@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,8 @@ jobs:
         run: python -m black --check --diff .
 
       - name: Run pylint
-        run: python -m pylint $(git ls-files '*.py')
+        run: |
+          pylint --rcfile=.pylintrc $(git diff --name-only origin/main...HEAD | grep '.py$')
 
       - name: Check GitHub rate limit at end
         uses: wakamex/rate-limit-action@master

--- a/.pylintrc
+++ b/.pylintrc
@@ -77,7 +77,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint.extensions.docparams, pylint.extensions.docstyle
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -617,3 +617,23 @@ variable-naming-style=snake_case
 # naming-style. If left empty, variable names will be checked with the set
 # naming style.
 #variable-rgx=
+[tool.pylint.parameter_documentation]
+# Whether to accept totally missing parameter documentation
+# in the docstring of a function that has parameters.
+accept-no-param-doc = false
+
+# Whether to accept totally missing raises documentation
+# in the docstring of a function that raises an exception.
+accept-no-raise-doc = true
+
+# Whether to accept totally missing return documentation in
+# the docstring of a function that returns a statement.
+accept-no-return-doc = false
+
+# Whether to accept totally missing yields documentation
+# in the docstring of a generator.
+accept-no-yields-doc = false
+
+# If the docstring type cannot be guessed the
+# specified docstring type will be used.
+default-docstring-type = numpy


### PR DESCRIPTION
Does two things:
  1. Enforces docstring linting in CI for all python files.
  2. Only lints files changed in a PR.  This will allow us to adopt the new docstring linting incrementally.

Enjoy! 😈 
  