### PR TITLE
Ease linting on test files

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -637,3 +637,6 @@ accept-no-yields-doc = false
 # If the docstring type cannot be guessed the
 # specified docstring type will be used.
 default-docstring-type = numpy
+
+[pylint.'test_*.py']
+disable = missing-param-doc, missing-return-doc, missing-return-type-doc, too-few-public-methods, missing-type-doc


### PR DESCRIPTION
Some of these don't make sense for test files.  Test functions don't need sphinx docs, and often don't have any public methods etc.
