### PR TITLE
add pandas stubs to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ with-dependencies = [
     "nbconvert",
     "numpy",
     "pandas",
+    "pandas-stubs",
     "pylint",
     "pyright",
     "pytest",


### PR DESCRIPTION
solves pyright errors like due to missing typehints.

example:
```
  /code/scrap/elfpy/data/postgres.py:514:16 - error: Argument of type "Literal['tokenValue']" cannot be assigned to parameter "values" of type "NoDefault" in function "pivot"
    Type "Literal['tokenValue']" cannot be assigned to type "NoDefault" (reportGeneralTypeIssues)
  /code/scrap/elfpy/data/postgres.py:514:36 - error: Argument of type "list[str]" cannot be assigned to parameter "index" of type "NoDefault" in function "pivot"
    Type "list[str]" cannot be assigned to type "NoDefault" (reportGeneralTypeIssues)
```
discussion here: https://github.com/pandas-dev/pandas/issues/49702