### PR TITLE
bugfixes & cleanup for bot workflow

### DIFF
--- a/examples/eth_bots/eth_bots_config.py
+++ b/examples/eth_bots/eth_bots_config.py
@@ -36,13 +36,13 @@ def get_eth_bots_config() -> tuple[EnvironmentConfig, list[AgentConfig]]:
         username_register_url="http://localhost:5002",
         artifacts_url="http://localhost:80",
         rpc_url="http://localhost:8545",
-        username="changeme",
+        username="changem3",
     )
 
     agent_config: list[AgentConfig] = [
         AgentConfig(
             policy=Policies.random_agent,
-            number_of_agents=1,
+            number_of_agents=5,
             base_budget=Budget(
                 mean_wei=int(5_000e18),  # 5k base
                 std_wei=int(1_000e18),  # 1k base

--- a/examples/eth_bots/eth_bots_config.py
+++ b/examples/eth_bots/eth_bots_config.py
@@ -36,13 +36,13 @@ def get_eth_bots_config() -> tuple[EnvironmentConfig, list[AgentConfig]]:
         username_register_url="http://localhost:5002",
         artifacts_url="http://localhost:80",
         rpc_url="http://localhost:8545",
-        username="changem3",
+        username="changeme",
     )
 
     agent_config: list[AgentConfig] = [
         AgentConfig(
             policy=Policies.random_agent,
-            number_of_agents=5,
+            number_of_agents=1,
             base_budget=Budget(
                 mean_wei=int(5_000e18),  # 5k base
                 std_wei=int(1_000e18),  # 1k base

--- a/examples/eth_bots/fund_bots.py
+++ b/examples/eth_bots/fund_bots.py
@@ -7,6 +7,7 @@ import os
 from dotenv import load_dotenv
 
 from elfpy import eth, hyperdrive_interface
+from examples.eth_bots.eth_bots_config import get_eth_bots_config
 
 if __name__ == "__main__":
     # get keys & RPC url from the environment
@@ -42,25 +43,18 @@ if __name__ == "__main__":
             f"{len(agent_accounts)=} must equal {len(agent_eth_budgets)=} and {len(agent_base_budgets)=}"
         )
 
-    # RPC URL
-    rpc_url = os.environ.get("RPC_URL")
-    if rpc_url is None:
-        raise ValueError("RPC_URL environment variable must be set")
-
-    # ARTIFACTS URL
-    artifacts_url = os.environ.get("ARTIFACTS_URL")
-    if artifacts_url is None:
-        raise ValueError("ARTIFACTS_URL environment variable must be set")
-
-    # ABI
-    base_abi_file = os.environ.get("BASE_ABI_FILE")
-    if base_abi_file is None:
-        raise ValueError("BASE_ABI_FILE environment variable must be set")
+    environment_config, agent_config = get_eth_bots_config()
 
     # setup web3 & contracts
-    web3 = eth.web3_setup.initialize_web3_with_http_provider(rpc_url)
-    base_contract_abi = eth.abi.load_abi_from_file(base_abi_file)
-    addresses = hyperdrive_interface.fetch_hyperdrive_address_from_url(os.path.join(artifacts_url, "addresses.json"))
+    web3 = eth.web3_setup.initialize_web3_with_http_provider(environment_config.rpc_url)
+    abi_file_loc = os.path.join(
+        os.path.join(environment_config.build_folder, environment_config.base_abi + ".sol"),
+        environment_config.base_abi + ".json",
+    )
+    base_contract_abi = eth.abi.load_abi_from_file(abi_file_loc)
+    addresses = hyperdrive_interface.fetch_hyperdrive_address_from_url(
+        os.path.join(environment_config.artifacts_url, "addresses.json")
+    )
     base_token_contract = web3.eth.contract(
         abi=base_contract_abi, address=web3.to_checksum_address(addresses.base_token)
     )

--- a/examples/eth_bots/populate_env.py
+++ b/examples/eth_bots/populate_env.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
             agent_base_budgets.append(agent_info.base_budget.sample_budget(rng).scaled_value)
             agent_eth_budgets.append(agent_info.eth_budget.sample_budget(rng).scaled_value)
     if args.user_key is not None:
-        print('export USER_KEY="' + str(parser.parse_args().user_key) + '"')
+        print("export USER_KEY='" + str(parser.parse_args().user_key) + "'")
     print("export AGENT_KEYS='" + json.dumps(agent_private_keys) + "'")
     print("export AGENT_BASE_BUDGETS='" + json.dumps(agent_base_budgets) + "'")
     print("export AGENT_ETH_BUDGETS='" + json.dumps(agent_eth_budgets) + "'")

--- a/examples/eth_bots/populate_env.py
+++ b/examples/eth_bots/populate_env.py
@@ -1,4 +1,5 @@
 """Helper script to generate a random private key."""
+import argparse
 import json
 import os
 
@@ -20,6 +21,16 @@ def make_key() -> str:
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="populate_env",
+        description="Script for generating a .env file for eth_bots.",
+        epilog=(
+            "Run the script with a user's private key as argument to include it in the output."
+            "See the README on https://github.com/delvtech/elf-simulations/eth_bots/ for more implementation details"
+        ),
+    )
+    parser.add_argument("user_key", nargs="?", help="Provide the user's private key to include it")
+    args = parser.parse_args()
     environment_config, agent_config = get_eth_bots_config()
     rng = np.random.default_rng(environment_config.random_seed)
     agent_private_keys = []
@@ -30,6 +41,8 @@ if __name__ == "__main__":
             agent_private_keys.append(make_key())
             agent_base_budgets.append(agent_info.base_budget.sample_budget(rng).scaled_value)
             agent_eth_budgets.append(agent_info.eth_budget.sample_budget(rng).scaled_value)
+    if args.user_key is not None:
+        print('export USER_KEY="' + str(parser.parse_args().user_key) + '"')
     print("export AGENT_KEYS='" + json.dumps(agent_private_keys) + "'")
     print("export AGENT_BASE_BUDGETS='" + json.dumps(agent_base_budgets) + "'")
     print("export AGENT_ETH_BUDGETS='" + json.dumps(agent_eth_budgets) + "'")

--- a/examples/eth_bots/populate_env.py
+++ b/examples/eth_bots/populate_env.py
@@ -1,6 +1,4 @@
 """Helper script to generate a random private key."""
-
-import argparse
 import json
 import os
 
@@ -12,46 +10,26 @@ from eth_utils.curried import text_if_str
 
 from examples.eth_bots.eth_bots_config import get_eth_bots_config
 
-# pylint: disable=invalid-name
-# pylint: disable=protected-access
-
 
 def make_key() -> str:
     """Make a private key"""
     extra_key_bytes = text_if_str(to_bytes, "SOME STR")
     key_bytes = keccak(os.urandom(32) + extra_key_bytes)
-    key = Account()._parsePrivateKey(key_bytes)
+    key = Account()._parsePrivateKey(key_bytes)  # pylint: disable=protected-access
     return str(key)
 
 
 if __name__ == "__main__":
-    # get keys & RPC url from the environment
-    parser = argparse.ArgumentParser(
-        prog="make_private_key",
-        description="Script for generating a private key",
-        epilog=(
-            "See the README on https://github.com/delvtech/elf-simulations/eth_bots/ for more implementation details"
-        ),
-    )
-    parser.add_argument(
-        "--use_config",
-        help="If True, generate keys per config agent; else just generate one key.",
-        action="store_true",
-    )
-    use_config: bool = bool(parser.parse_args().use_config)
-    if use_config:
-        environment_config, agent_config = get_eth_bots_config()
-        rng = np.random.default_rng(environment_config.random_seed)
-        agent_private_keys = []
-        agent_base_budgets = []
-        agent_eth_budgets = []
-        for agent_info in agent_config:
-            for policy_instance_index in range(agent_info.number_of_agents):
-                agent_private_keys.append(make_key())
-                agent_base_budgets.append(agent_info.base_budget.sample_budget(rng).scaled_value)
-                agent_eth_budgets.append(agent_info.eth_budget.sample_budget(rng).scaled_value)
-        print("export AGENT_KEYS='" + json.dumps(agent_private_keys) + "'")
-        print("export AGENT_BASE_BUDGETS='" + json.dumps(agent_base_budgets) + "'")
-        print("export AGENT_ETH_BUDGETS='" + json.dumps(agent_eth_budgets) + "'")
-    else:
-        print("export AGENT_KEYS='[\"" + make_key() + "\"]'")
+    environment_config, agent_config = get_eth_bots_config()
+    rng = np.random.default_rng(environment_config.random_seed)
+    agent_private_keys = []
+    agent_base_budgets = []
+    agent_eth_budgets = []
+    for agent_info in agent_config:
+        for policy_instance_index in range(agent_info.number_of_agents):
+            agent_private_keys.append(make_key())
+            agent_base_budgets.append(agent_info.base_budget.sample_budget(rng).scaled_value)
+            agent_eth_budgets.append(agent_info.eth_budget.sample_budget(rng).scaled_value)
+    print("export AGENT_KEYS='" + json.dumps(agent_private_keys) + "'")
+    print("export AGENT_BASE_BUDGETS='" + json.dumps(agent_base_budgets) + "'")
+    print("export AGENT_ETH_BUDGETS='" + json.dumps(agent_eth_budgets) + "'")


### PR DESCRIPTION
New workflow for funding bots:

1. Generate a private key for your user account. I recommend using one of the private keys Anvil provides when spinning up the docker devnet. These keys are already funded with Ethereum and Base. If you choose to use a different key, make sure you run the code to give it money before proceeding.

2. Modify `examples/eth_bots/eth_bots_config.py` as you see fit for your experiment.
4. Run the `populate_env` script with your private key as an argument, and pipe the output to a `.env` file. For example:

**NOTE:** This command overwrites your `.env` file, so make sure you're ok with losing whatever contents are in it first!

```bash
python examples/eth_bots/populate_env.py 0xUSERKEY > .env
```
This will generate new environment variables for the bots and write them to the `.env` file. The new variables are private keys, base budgets, and eth budgets for all of the agents you specified in your config. This is what your `.env` file might look like after:
```bash
export USER_KEY="0xUSER_PRIVATE_KEY"
export AGENT_KEYS='["0xAGENT_PRIVATE_KEY"]'
export AGENT_BASE_BUDGETS='[3396163194603698651136]'
export AGENT_ETH_BUDGETS='[1000000000000000000]'
```

5. Run `python examples/eth_bots/fund_bots.py` to fund your bots. This file will parse the `.env` file and allocate the budgets for Ethereum and Base by transferring it from the wallet corresponding to the `USER_KEY` environment variable.
6. Run `python examples/eth_bots/main.py` to start trading!