### PR TITLE
Remove slippage defaults from policies

### DIFF
--- a/elfpy/agents/policies/base.py
+++ b/elfpy/agents/policies/base.py
@@ -1,4 +1,5 @@
 """Base policy class. Subclasses of BasicPolicy will implement trade actions."""
+
 from __future__ import annotations
 
 import logging
@@ -19,7 +20,7 @@ class BasePolicy:
     """Base class policy"""
 
     def __init__(
-        self, budget: FixedPoint, rng: NumpyGenerator | None = None, slippage_tolerance: FixedPoint = FixedPoint(0.0001)
+        self, budget: FixedPoint, rng: NumpyGenerator | None = None, slippage_tolerance: FixedPoint | None = None
     ):
         if not isinstance(budget, FixedPoint):
             raise TypeError(f"{budget=} must be of type `FixedPoint`")

--- a/elfpy/agents/policies/lp_and_withdraw.py
+++ b/elfpy/agents/policies/lp_and_withdraw.py
@@ -31,7 +31,7 @@ class LpAndWithdrawAgent(BasePolicy):
         self,
         budget: FixedPoint = FixedPoint("1000.0"),
         rng: NumpyGenerator | None = None,
-        slippage_tolerance: FixedPoint = FixedPoint("0.0001"),
+        slippage_tolerance: FixedPoint | None = None,
         amount_to_lp: FixedPoint = FixedPoint("100.0"),
         time_to_withdraw: FixedPoint = FixedPoint("1.0"),
     ):

--- a/elfpy/agents/policies/random_agent.py
+++ b/elfpy/agents/policies/random_agent.py
@@ -25,7 +25,7 @@ class RandomAgent(BasePolicy):
         self,
         budget: FixedPoint = FixedPoint("10_000.0"),
         rng: NumpyGenerator | None = None,
-        slippage_tolerance: FixedPoint = FixedPoint("0.0001"),
+        slippage_tolerance: FixedPoint | None = None,
         trade_chance: FixedPoint = FixedPoint("1.0"),
     ) -> None:
         """Adds custom attributes."""

--- a/elfpy/agents/policies/single_lp.py
+++ b/elfpy/agents/policies/single_lp.py
@@ -26,7 +26,7 @@ class SingleLpAgent(BasePolicy):
         self,
         budget: FixedPoint = FixedPoint("1000.0"),
         rng: NumpyGenerator | None = None,
-        slippage_tolerance: FixedPoint = FixedPoint("0.0001"),
+        slippage_tolerance: FixedPoint | None = None,
         amount_to_lp: FixedPoint = FixedPoint("100.0"),
     ):
         """call basic policy init then add custom stuff"""

--- a/elfpy/agents/policies/single_short.py
+++ b/elfpy/agents/policies/single_short.py
@@ -28,7 +28,7 @@ class SingleShortAgent(BasePolicy):
         self,
         budget: FixedPoint = FixedPoint("100.0"),
         rng: NumpyGenerator | None = None,
-        slippage_tolerance: FixedPoint = FixedPoint("0.0001"),
+        slippage_tolerance: FixedPoint | None = None,
         amount_to_trade: FixedPoint | None = None,
     ):
         """call basic policy init then add custom stuff"""

--- a/elfpy/agents/policies/smart_long.py
+++ b/elfpy/agents/policies/smart_long.py
@@ -41,7 +41,7 @@ class LongLouie(BasePolicy):
         rng: NumpyGenerator,
         trade_chance: FixedPoint,
         risk_threshold: FixedPoint,
-        slippage_tolerance: FixedPoint = FixedPoint("0.0001"),
+        slippage_tolerance: FixedPoint | None = None,
     ) -> None:
         """Add custom stuff then call basic policy init"""
         if not isinstance(trade_chance, FixedPoint):

--- a/elfpy/agents/policies/smart_short.py
+++ b/elfpy/agents/policies/smart_short.py
@@ -43,7 +43,7 @@ class ShortSally(BasePolicy):
         rng: NumpyGenerator,
         trade_chance: FixedPoint,
         risk_threshold: FixedPoint,
-        slippage_tolerance: FixedPoint = FixedPoint("0.0001"),
+        slippage_tolerance: FixedPoint | None = None,
     ) -> None:
         """Add custom stuff then call basic policy init"""
         if not isinstance(trade_chance, FixedPoint):

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -55,8 +55,8 @@ class HyperdriveMarketAction(BaseMarketAction):
     trade_amount: FixedPoint  # TODO: should this be a Quantity, not a float? Make sure, then delete fixme
     # the agent's wallet
     wallet: Wallet
-    # slippage tolerance defaults to 0.01% for trades
-    slippage_tolerance: FixedPoint = FixedPoint(0.0001)
+    # slippage tolerance percent where 0.01 would be a 1% tolerance
+    slippage_tolerance: FixedPoint | None = None
     # mint time is set only for trades that act on existing positions (close long or close short)
     mint_time: FixedPoint | None = None
 

--- a/examples/eth_bots/custom_policies/example_custom_policy.py
+++ b/examples/eth_bots/custom_policies/example_custom_policy.py
@@ -36,10 +36,7 @@ class ExampleCustomPolicy(BasePolicy):
         else:
             self.trade_amount: FixedPoint = trade_amount
 
-        if slippage_tolerance is None:
-            super().__init__(budget, rng)
-        else:
-            super().__init__(budget, rng, slippage_tolerance)
+        super().__init__(budget, rng, slippage_tolerance)
 
     def action(self, market: HyperdriveMarket, wallet: Wallet) -> list[Trade]:
         """Specify actions.

--- a/examples/eth_bots/execute_agent_trades.py
+++ b/examples/eth_bots/execute_agent_trades.py
@@ -235,9 +235,13 @@ async def async_match_contract_call_to_trade(
             fn_args = (trade_amount, min_output, account.checksum_address, as_underlying)
             preview_result = smart_contract_preview_transaction(hyperdrive_contract, account, "openLong", *fn_args)
             min_output = (
-                FixedPoint(scaled_value=preview_result["bondProceeds"])
-                * (FixedPoint(1) - trade.trade.slippage_tolerance)
-            ).scaled_value
+                (
+                    FixedPoint(scaled_value=preview_result["bondProceeds"])
+                    * (FixedPoint(1) - trade.trade.slippage_tolerance)
+                ).scaled_value
+                if trade.trade.slippage_tolerance
+                else 0
+            )
             fn_args = (trade_amount, min_output, account.checksum_address, as_underlying)
 
             trade_result = await async_transact_and_parse_logs(
@@ -271,8 +275,12 @@ async def async_match_contract_call_to_trade(
             )
             preview_result = smart_contract_preview_transaction(hyperdrive_contract, account, "closeLong", *fn_args)
             min_output = (
-                FixedPoint(scaled_value=preview_result["value"]) * (FixedPoint(1) - trade.trade.slippage_tolerance)
-            ).scaled_value
+                (
+                    FixedPoint(scaled_value=preview_result["value"]) * (FixedPoint(1) - trade.trade.slippage_tolerance)
+                ).scaled_value
+                if trade.trade.slippage_tolerance
+                else 0
+            )
             fn_args = (decoded_maturity_time_seconds, trade_amount, min_output, account.checksum_address, as_underlying)
             trade_result = await async_transact_and_parse_logs(
                 web3,
@@ -293,9 +301,13 @@ async def async_match_contract_call_to_trade(
             fn_args = (trade_amount, max_deposit, account.checksum_address, as_underlying)
             preview_result = smart_contract_preview_transaction(hyperdrive_contract, account, "openShort", *fn_args)
             max_deposit = (
-                FixedPoint(scaled_value=preview_result["traderDeposit"])
-                * (FixedPoint(1) + trade.trade.slippage_tolerance)
-            ).scaled_value
+                (
+                    FixedPoint(scaled_value=preview_result["traderDeposit"])
+                    * (FixedPoint(1) + trade.trade.slippage_tolerance)
+                ).scaled_value
+                if trade.trade.slippage_tolerance
+                else 0
+            )
             fn_args = (trade_amount, max_deposit, account.checksum_address, as_underlying)
             trade_result = await async_transact_and_parse_logs(
                 web3,
@@ -332,8 +344,13 @@ async def async_match_contract_call_to_trade(
             )
             preview_result = smart_contract_preview_transaction(hyperdrive_contract, account, "closeShort", *fn_args)
             min_output = (
-                FixedPoint(scaled_value=preview_result["value"]) * (FixedPoint(1) - trade.trade.slippage_tolerance)
-            ).scaled_value
+                (
+                    FixedPoint(scaled_value=preview_result["value"]) * (FixedPoint(1) - trade.trade.slippage_tolerance)
+                ).scaled_value
+                if trade.trade.slippage_tolerance
+                else 0
+            )
+
             fn_args = (decoded_maturity_time_seconds, trade_amount, min_output, account.checksum_address, as_underlying)
             trade_result = await async_transact_and_parse_logs(
                 web3,


### PR DESCRIPTION
We had several defaults for slippage tolerance throughout the repo.  Now, the slippage_tolerance is only set in the AgentConfig.  