### PR TITLE
Add get_balance_for_account and mint_tokens_for_account bash scripts

### DIFF
--- a/scripts/get_balance_for_account.sh
+++ b/scripts/get_balance_for_account.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+source .env
+
+# Function to display script usage
+usage() {
+  echo "Usage: $0 --rpc_url=<RPC_URL> --base_token=<BASE_TOKEN> --account=<ACCOUNT>"
+  exit 1
+}
+
+# Parse command-line options
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --rpc_url=*)
+      rpc_url="${key#*=}"
+      ;;
+    --base_token=*)
+      base_token="${key#*=}"
+      ;;
+    --account=*)
+      account="${key#*=}"
+      ;;
+    *)
+      echo "Invalid option: $key" >&2
+      usage
+      ;;
+  esac
+  shift
+done
+
+# Check if all required flags are provided
+if [[ -z $rpc_url || -z $base_token || -z $account ]]; then
+  echo "Error: All flags (--rpc_url, --base_token, --account) must be provided."
+  usage
+fi
+
+# Check if the Ethereum node is reachable
+if curl -s -o /dev/null --connect-timeout 5 "$rpc_url"; then
+  echo "Ethereum node is reachable."
+else
+  echo "Error: Ethereum node is not reachable at the provided RPC URL: $rpc_url"
+  exit 1
+fi
+
+# Wait until the Ethereum node is ready
+while true; do
+  if curl -s -X POST --header "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}' "$rpc_url" | grep -q "result"; then
+    break
+  fi
+  echo "Waiting for Ethereum node to be ready..."
+  sleep 1
+done
+
+# get balance for account
+result_hex=$(cast call "$base_token" "balanceOf(address)" "$account" --rpc-url "$rpc_url")
+result_dec=$(cast to-dec "$result_hex")
+
+# # Divide the result by 10^18 (add a decimal point 18 places from the right)
+result_dec_with_decimal=$(echo "scale=18; $result_dec / 1000000000000000000" | bc)
+
+echo "Result in hexadecimal: $result_hex"
+echo "Result in decimal: $result_dec"
+echo "Result in decimal: $result_dec_with_decimal"

--- a/scripts/mint_tokens_for_account.sh
+++ b/scripts/mint_tokens_for_account.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+source .env
+
+# Function to display script usage
+usage() {
+  echo "Usage: $0 --rpc_url=<RPC_URL> --base_token=<BASE_TOKEN> --amount=<AMOUNT>"
+  exit 1
+}
+
+# Parse command-line options
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --rpc_url=*)
+      rpc_url="${key#*=}"
+      ;;
+    --base_token=*)
+      base_token="${key#*=}"
+      ;;
+    --amount=*)
+      amount="${key#*=}"
+      ;;
+    *)
+      echo "Invalid option: $key" >&2
+      usage
+      ;;
+  esac
+  shift
+done
+
+# Check if all required flags are provided
+if [[ -z $rpc_url || -z $base_token || -z $amount ]]; then
+  echo "Error: All flags (--rpc_url, --base_token, --amount) must be provided."
+  usage
+fi
+
+# Check if the Ethereum node is reachable
+if curl -s -o /dev/null --connect-timeout 5 "$rpc_url"; then
+  echo "Ethereum node is reachable."
+else
+  echo "Error: Ethereum node is not reachable at the provided RPC URL: $rpc_url"
+  exit 1
+fi
+
+# Wait until the Ethereum node is ready
+while true; do
+  if curl -s -X POST --header "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}' "$rpc_url" | grep -q "result"; then
+    break
+  fi
+  echo "Waiting for Ethereum node to be ready..."
+  sleep 1
+done
+
+echo "--------------------------------"
+echo "        MINT TOKENS             "
+echo "--------------------------------"
+
+# Use bc for arbitrary precision arithmetic
+multiplied_amount=$(echo "$amount * 1000000000000000000" | bc)
+echo "multiplied_amount: $multiplied_amount"
+
+# Convert the multiplied amount to a hexadecimal string
+amount_hex="0x$(echo "obase=16; $multiplied_amount" | bc)"
+echo "amount_hex: $amount_hex"
+
+# mint tokens for account
+cast send "$base_token" "mint(uint256)" "$amount_hex" --rpc-url "$rpc_url" --private-key "$USER_KEY"
+
+echo "--------------------------------"
+echo " ACCOUNT FUNDED SUCCESSFULLY!! "
+echo "--------------------------------"


### PR DESCRIPTION
We need more low level tools to help us fund bots and see what's going on.  I chose to use foundry's cast for this because cast doesn't need to know any abi information, just the contract addresses you want to interact with.  Here are some examples:

```bash
❯❯ ./scripts/get_balance_for_account.sh
Error: All flags (--rpc_url, --base_token, --account) must be provided.
Usage: ./scripts/get_balance_for_account.sh --rpc_url=<RPC_URL> --base_token=<BASE_TOKEN> --account=<ACCOUNT>
```

```bash
❯❯ ./scripts/get_balance_for_account.sh --rpc_url=localhost:8545 --base_token=0x5FbDB2315678afecb367f032d93F642f64180aa3 --account=0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
Ethereum node is reachable.
Result in hexadecimal: 0x00000000000000000000000000000000000000000009ea5f875f5c11fdd7fff9
Result in decimal: 11987128328826712210538489
Result in decimal: 11987128.328826712210538489
```



