### PR TITLE
Updating installation to allow for installing individual subpackages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,19 +49,6 @@ An explanation of what the above steps do:
 
 Finally, you can test that everything is working by calling: `python -m pytest .`
 
-## Installing individual subpackages (optional)
-The default installation directions above should automatically install all local sub-packages, and should be sufficient for development.
-
-We also support installing each subpackage independently. For example:
-```
-python -m pip install --upgrade lib/agent0[with-dependencies]
-```
-Internally, the above installation calls
-```
-pip install agent0[base] # Install with base packages only (this is what's called in requirements.txt)
-pip install agent0[lateral] # Installs dependent sub-packages from git (e.g., ethpy)
-```
-
 ## Working with smart contracts (optional)
 
 We run tests and offer utilities that depend on executing bytecode compiled from Hyperdrive solidity contracts. This is not required to use elfpy.
@@ -83,6 +70,18 @@ ln -s ../hyperdrive hyperdrive_solidity
 Complete the steps in Hyperdrive's [Pre-requisites](https://github.com/delvtech/hyperdrive#pre-requisites) and [Build](https://github.com/delvtech/hyperdrive#build) sections.
 
 ## Notes
+
+The default installation directions above should automatically install all local sub-packages, and should be sufficient for development.
+
+We also support installing each subpackage independently. For example:
+```
+python -m pip install --upgrade lib/agent0[with-dependencies]
+```
+Internally, the above installation calls
+```
+pip install agent0[base] # Install with base packages only (this is what's called in requirements.txt)
+pip install agent0[lateral] # Installs dependent sub-packages from git (e.g., ethpy)
+```
 
 You can test against a local testnet node using [Anvil](<[url](https://book.getfoundry.sh/reference/anvil/)>) with `anvil`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,6 +49,19 @@ An explanation of what the above steps do:
 
 Finally, you can test that everything is working by calling: `python -m pytest .`
 
+## Installing individual subpackages (optional)
+The default installation directions above should automatically install all local sub-packages, and should be sufficient for development.
+
+We also support installing each subpackage independently. For example:
+```
+python -m pip install --upgrade lib/agent0[with-dependencies]
+```
+Internally, the above installation calls
+```
+pip install agent0[base] # Install with base packages only (this is what's called in requirements.txt)
+pip install agent0[lateral] # Installs dependent sub-packages from git (e.g., ethpy)
+```
+
 ## Working with smart contracts (optional)
 
 We run tests and offer utilities that depend on executing bytecode compiled from Hyperdrive solidity contracts. This is not required to use elfpy.

--- a/lib/agent0/pyproject.toml
+++ b/lib/agent0/pyproject.toml
@@ -16,22 +16,27 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-dependencies = [
-    # Lateral dependencies across subpackages are pointing to github
-    # TODO test that outermost pip install overwrites this
-    # TODO move this to either this monorepo or seperate repo
+[project.optional-dependencies]
+# This flag installs all dependencies and should be ran when installing this subpackage in isolation
+with-dependencies = [
+    "agent0[base, lateral]"
+]
+base = [
+    # TODO move fixedpointmath to lateral if this package comes back to this monorepo
     "fixedpointmath @ git+https://github.com/delvtech/agent_0.git/#subdirectory=lib/fixedpointmath",
-    # TODO this might not work since it's not on github yet, need to test
-    #"elfpy @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/elfpy",
-    #"ethpy @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/ethpy",
-    #"chainsync @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/chainsync",
-    # TODO figure out the dependencies below
     "numpy",
     "requests",
     "python-dotenv",
     "web3", # will include eth- packages
     "hexbytes"
 ]
+lateral = [
+    # Lateral dependencies across subpackages are pointing to github
+    "elfpy @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/elfpy",
+    "ethpy @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/ethpy",
+    "chainsync @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/chainsync",
+]
+
 
 [build-system]
 requires = ["flit_core>=3.2"]

--- a/lib/chainsync/pyproject.toml
+++ b/lib/chainsync/pyproject.toml
@@ -16,14 +16,14 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-dependencies = [
-    # Lateral dependencies across subpackages are pointing to github
-    # TODO test that outermost pip install overwrites this
-    # TODO move this to either this monorepo or seperate repo
-    #"fixedpointmath @ git+https://github.com/delvtech/agent_0.git/#subdirectory=lib/fixedpointmath",
-    # TODO this might not work since it's not on github yet, need to test
-    #"elfpy @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/elfpy",
-    #"ethpy @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/ethpy",
+[project.optional-dependencies]
+# This flag installs all dependencies and should be ran when installing this subpackage in isolation
+with-dependencies = [
+    "chainsync[base, lateral]"
+]
+base = [
+    # TODO move fixedpointmath to lateral if this package comes back to this monorepo
+    "fixedpointmath @ git+https://github.com/delvtech/agent_0.git/#subdirectory=lib/fixedpointmath",
     # TODO figure out the dependencies below
     "matplotlib",
     "numpy",
@@ -36,6 +36,11 @@ dependencies = [
     "psycopg2-binary",
     "sqlalchemy",
     "pandas-stubs",
+]
+lateral = [
+    # Lateral dependencies across subpackages are pointing to github
+    "elfpy @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/elfpy",
+    "ethpy @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/ethpy",
 ]
 
 [build-system]

--- a/lib/elfpy/pyproject.toml
+++ b/lib/elfpy/pyproject.toml
@@ -24,16 +24,21 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-dependencies = [
-    # Lateral dependencies across subpackages are pointing to github
-    # TODO test that outermost pip install overwrites this
-    # TODO move this to either this monorepo or seperate repo
+[project.optional-dependencies]
+# This flag installs all dependencies and should be ran when installing this subpackage in isolation
+with-dependencies = [
+    "elfpy[base, lateral]"
+]
+base = [
+    # TODO move fixedpointmath to lateral if this package comes back to this monorepo
     "fixedpointmath @ git+https://github.com/delvtech/agent_0.git/#subdirectory=lib/fixedpointmath",
     # TODO figure out the dependencies below
     "matplotlib",
     "numpy",
     "pandas",
     "python-dotenv",
+]
+lateral = [
 ]
 
 [project.urls]

--- a/lib/ethpy/pyproject.toml
+++ b/lib/ethpy/pyproject.toml
@@ -16,18 +16,24 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-dependencies = [
-    # Lateral dependencies across subpackages are pointing to github
-    # TODO test that outermost pip install overwrites this
-    # TODO move this to either this monorepo or seperate repo
-    #"fixedpointmath @ git+https://github.com/delvtech/agent_0.git/#subdirectory=lib/fixedpointmath",
-    #"elfpy @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/elfpy",
+[project.optional-dependencies]
+# This flag installs all dependencies and should be ran when installing this subpackage in isolation
+with-dependencies = [
+    "ethpy[base, lateral]"
+]
+base = [
+    # TODO move fixedpointmath to lateral if this package comes back to this monorepo
+    "fixedpointmath @ git+https://github.com/delvtech/agent_0.git/#subdirectory=lib/fixedpointmath",
     # TODO figure out the dependencies below
     "matplotlib",
     "numpy",
     "pandas",
     "python-dotenv",
     "web3",
+]
+lateral = [
+    # Lateral dependencies across subpackages are pointing to github
+    "elfpy @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/elfpy",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # TODO Ordering might matter here for dependency resolution
--e lib/agent0
--e lib/chainsync
--e lib/elfpy
--e lib/ethpy
+-e lib/elfpy[base]
+-e lib/agent0[base]
+-e lib/chainsync[base]
+-e lib/ethpy[base]


### PR DESCRIPTION
This solves the issue of specifying lateral dependencies for solo installation. The installation now allows for several optional tags for installation. For example, for agent0:

```
pip install agent0[with-dependencies] # Install individual subpackage
pip install agent0[base] # Install with base packages only (this is what's called in requirements.txt)
```

Note this doesn't change anything on default dev installation, i.e.,
```
pip install -r requirements.txt
```