### PR TITLE
fix: log wallet address as string

### DIFF
--- a/lib/agent0/agent0/hyperdrive/agents/hyperdrive_wallet.py
+++ b/lib/agent0/agent0/hyperdrive/agents/hyperdrive_wallet.py
@@ -52,8 +52,8 @@ class HyperdriveWallet(EthWallet):
         for maturity_time, long in longs:
             if long.balance != FixedPoint(0):
                 logging.debug(
-                    "agent #%g trade longs, maturity_time = %g\npre-trade amount = %s\ntrade delta = %s",
-                    self.address,
+                    "agent %s trade longs, maturity_time = %g\npre-trade amount = %s\ntrade delta = %s",
+                    self.address.hex(),
                     maturity_time,
                     self.longs,
                     long,
@@ -81,8 +81,8 @@ class HyperdriveWallet(EthWallet):
         for maturity_time, short in shorts:
             if short.balance != FixedPoint(0):
                 logging.debug(
-                    "agent #%g trade shorts, maturity_time = %s\npre-trade amount = %s\ntrade delta = %s",
-                    self.address,
+                    "agent %s trade shorts, maturity_time = %s\npre-trade amount = %s\ntrade delta = %s",
+                    self.address.hex(),
                     maturity_time,
                     self.shorts,
                     short,
@@ -129,8 +129,8 @@ class HyperdriveWallet(EthWallet):
                     continue
                 case "lp_tokens" | "withdraw_shares":
                     logging.debug(
-                        "agent #%g %s pre-trade = %.0g\npost-trade = %1g\ndelta = %1g",
-                        self.address,
+                        "agent %s %s pre-trade = %.0g\npost-trade = %1g\ndelta = %1g",
+                        self.address.hex(),
                         key,
                         getattr(self, key),
                         getattr(self, key) + value_or_dict,
@@ -140,8 +140,8 @@ class HyperdriveWallet(EthWallet):
                 # handle updating a Quantity
                 case "balance":
                     logging.debug(
-                        "agent #%g %s pre-trade = %.0g\npost-trade = %1g\ndelta = %1g",
-                        self.address,
+                        "agent %s %s pre-trade = %.0g\npost-trade = %1g\ndelta = %1g",
+                        self.address.hex(),
                         key,
                         float(getattr(self, key).amount),
                         float(getattr(self, key).amount + value_or_dict.amount),


### PR DESCRIPTION
error was:

```
  File "/home/mihai/.pyenv/versions/3.10.11/lib/python3.10/logging/__init__.py", line 368, in getMessage
    msg = msg % self.args
TypeError: must be real number, not HexBytes
Call stack:
  File "/code/mihaipy/lib/agent0/bin/run_hyperdrive_agents.py", line 73, in <module>
    main()
...
  File "/code/mihaipy/lib/agent0/agent0/hyperdrive/agents/hyperdrive_wallet.py", line 54, in _update_longs
    logging.debug(
Message: 'agent #%g trade longs, maturity_time = %g\npre-trade amount = %s\ntrade delta = %s'
Arguments: (HexBytes('0x7eea1f9ac718dcc9fb13d66ed76845dc46abac65'), FixedPoint("1692136800.0"), {}, Long(balance=FixedPoint("349.030040954063607256")))
agent #b'~\xea\x1f\x9a\xc7\x18\xdc\xc9\xfb\x13\xd6n\xd7hE\xdcF\xab\xace' withdraw_shares pre-trade = 0.003
```

wallet address is now a string, but it used to be an int:
https://github.com/delvtech/elf-simulations/blob/61d023ec168faa433b7ecb7279843d701c36e675/lib/elfpy/elfpy/agents/agent.py#L28