### PR TITLE
System tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Please refer to [BUILD.md](https://github.com/delvtech/elf-simulations/blob/main
 
 ## Testing
 
+We deploy a local anvil chain to run system tests. Therefore, you must [install foundry](https://github.com/foundry-rs/foundry#installatio://github.com/foundry-rs/foundry#installation) as a prerequisite for running tests.
+
 Testing is achieved with [py.test](https://docs.pytest.org/en/latest/contents.html). You can run all tests from the repository root directory by running `python -m pytest`, or you can pick a specific test in the `tests/` folder with `python -m pytest tests/{test_file.py}`.
 
 ## Coverage

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 # Hack to allow for vscode debugger to throw exception immediately
 # instead of allowing pytest to catch the exception and report
+# Based on https://stackoverflow.com/questions/62419998/how-can-i-get-pytest-to-not-catch-exceptions/62563106#62563106
+
 # Use this in conjunction with the following launch.json configuration:
 #      {
 #        "name": "Debug Tests",

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@
 
 # Use this in conjunction with the following launch.json configuration:
 #      {
-#        "name": "Debug Tests",
+#        "name": "Debug Current Test",
 #        "type": "python",
 #        "request": "launch",
 #        "module": "pytest",

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,33 @@
+# Hack to allow for vscode debugger to throw exception immediately
+# instead of allowing pytest to catch the exception and report
+# Use this in conjunction with the following launch.json configuration:
+#      {
+#        "name": "Debug Tests",
+#        "type": "python",
+#        "request": "launch",
+#        "module": "pytest",
+#        "args": ["${file}"],
+#        "console": "integratedTerminal",
+#        "justMyCode": true,
+#        "env": {
+#            "_PYTEST_RAISE": "1"
+#        },
+#      },
+
+# Ignore docstrings for this file
+# pylint: disable=missing-docstring
+
+
+import os
+
+import pytest
+
+if os.getenv("_PYTEST_RAISE", "0") != "0":
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_exception_interact(call):
+        raise call.excinfo.value
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_internalerror(excinfo):
+        raise excinfo.value

--- a/lib/agent0/agent0/__init__.py
+++ b/lib/agent0/agent0/__init__.py
@@ -1,2 +1,7 @@
 """Account key config and various helper functions"""
-from .accounts_config import AccountKeyConfig, build_account_config_from_env, initialize_accounts
+from .accounts_config import (
+    AccountKeyConfig,
+    build_account_config_from_env,
+    build_account_key_config_from_agent_config,
+    initialize_accounts,
+)

--- a/lib/agent0/agent0/accounts_config.py
+++ b/lib/agent0/agent0/accounts_config.py
@@ -58,13 +58,33 @@ class AccountKeyConfig:
 
 
 def initialize_accounts(
-    agent_config: list[AgentConfig], env_file: str | None = None, random_seed: int = 1, develop: bool = False
+    agent_config: list[AgentConfig],
+    env_file: str | None = None,
+    random_seed: int = 1,
+    develop: bool = False,
 ) -> AccountKeyConfig:
     """
     Build or load an accounts environment file.
     If it doesn't exist, create it based on agent_config.
     (if develop is off, print instructions on adding in user private key and running script to fund agents).
     If it does exist, read it in and use it.
+
+    Arguments
+    ---------
+    agent_config: list[AgentConfig]
+        The list of agent configs that define policies and arguments.
+    env_file: str | None
+        The path to the env file to write/load from. Defaults to `accounts.env`.
+    random_seed: int
+        Random seed to use for initializing budgets.
+    develop: bool
+        Flag for development mode. If False, will exit if env_file doesn't exist and print instructions
+        on how to fund bot.
+
+    Returns
+    -------
+    AccountKeyConfig
+        The account config object linked to the env file.
     """
     # Default location
     if env_file is None:
@@ -102,21 +122,23 @@ def initialize_accounts(
 
 
 def build_account_key_config_from_agent_config(
-    agent_configs: list[AgentConfig], random_seed: int, user_key: str | None = None
+    agent_configs: list[AgentConfig], random_seed: int = 1, user_key: str | None = None
 ) -> AccountKeyConfig:
     """Build an Account Config from a provided agent config.
 
     Arguments
     --------
+    agent_config: list[AgentConfig]
+        The list of agent configs that define policies and arguments.
+    random_seed: int
+        The seed to initialize the random generator to pass for each bot
     user_key: str
         The provided user key to use
-    agent_configs: list[AgentConfig]
-        The provided agent configs
 
     Returns
     -------
-    AccountConfig
-        Config settings required to connect to the eth node
+    AccountKeyConfig
+        The account config object linked to the env file.
     """
     rng = np.random.default_rng(random_seed)
     agent_private_keys = []
@@ -150,6 +172,13 @@ def build_account_key_config_from_agent_config(
 
 def build_account_config_from_env(env_file: str | None = None, user_key: str | None = None) -> AccountKeyConfig:
     """Build an Account Config from environmental variables.
+
+    Arguments
+    --------
+    env_file: str | None
+        The path to the env file to load from. Defaults to `accounts.env`.
+    user_key: str
+        The provided user key to use
 
     Returns
     -------

--- a/lib/agent0/agent0/hyperdrive/exec/__init__.py
+++ b/lib/agent0/agent0/hyperdrive/exec/__init__.py
@@ -12,5 +12,5 @@ from .execute_agent_trades import (
 from .fund_agents import fund_agents
 from .get_agent_accounts import get_agent_accounts
 from .run_agents import run_agents
-from .setup_experiment import get_web3_and_contracts, register_username, setup_experiment
+from .setup_experiment import register_username, setup_experiment
 from .trade_loop import get_wait_for_new_block, trade_if_new_block

--- a/lib/agent0/agent0/hyperdrive/exec/create_and_fund_user_account.py
+++ b/lib/agent0/agent0/hyperdrive/exec/create_and_fund_user_account.py
@@ -7,9 +7,7 @@ from agent0.hyperdrive.agents import HyperdriveAgent
 from eth_account.account import Account
 from ethpy import EthConfig
 from ethpy.base import set_anvil_account_balance, smart_contract_transact
-from ethpy.hyperdrive.addresses import HyperdriveAddresses
-
-from .setup_experiment import get_web3_and_contracts
+from ethpy.hyperdrive import HyperdriveAddresses, get_web3_and_hyperdrive_contracts
 
 
 def create_and_fund_user_account(
@@ -38,7 +36,7 @@ def create_and_fund_user_account(
     user_private_key = make_private_key(extra_entropy="FAKE USER")  # argument value can be any str
     user_account = HyperdriveAgent(Account().from_key(user_private_key))
 
-    web3, base_token_contract, _ = get_web3_and_contracts(eth_config, contract_addresses)
+    web3, base_token_contract, _ = get_web3_and_hyperdrive_contracts(eth_config, contract_addresses)
 
     eth_balance = sum((int(budget) for budget in account_key_config.AGENT_ETH_BUDGETS)) * 2  # double for good measure
     _ = set_anvil_account_balance(web3, user_account.address, eth_balance)

--- a/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
@@ -15,7 +15,7 @@ from ethpy.base import (
     smart_contract_read,
     smart_contract_transact,
 )
-from ethpy.hyperdrive.addresses import HyperdriveAddresses
+from ethpy.hyperdrive import HyperdriveAddresses
 
 
 def fund_agents(

--- a/lib/agent0/agent0/hyperdrive/exec/run_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/run_agents.py
@@ -26,7 +26,7 @@ def run_agents(
     account_key_config: AccountKeyConfig,
     develop: bool = False,
     eth_config: EthConfig | None = None,
-    override_addresses: HyperdriveAddresses | None = None,
+    contract_addresses: HyperdriveAddresses | None = None,
 ) -> None:
     """Entrypoint to run agents.
 
@@ -43,24 +43,22 @@ def run_agents(
     eth_config: EthConfig | None
         Configuration for urls to the rpc and artifacts. If not set, will look for addresses
         in eth.env.
-    override_addresses: HyperdriveAddresses | None
+    contract_addresses: HyperdriveAddresses | None
         If set, will use these addresses instead of querying the artifact url
         defined in eth_config.
     """
-
-    # Defaults to looking for eth_config env
-    if eth_config is None:
-        eth_config = build_eth_config()
 
     # Set sane logging defaults to avoid spam from dependencies
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logging.getLogger("web3").setLevel(logging.WARNING)
     warnings.filterwarnings("ignore", category=UserWarning, module="web3.contract.base_contract")
 
-    # Get addresses either from artifacts url defined in eth_config or from override_addresses
-    if override_addresses is not None:
-        contract_addresses = override_addresses
-    else:
+    # Defaults to looking for eth_config env
+    if eth_config is None:
+        eth_config = build_eth_config()
+
+    # Get addresses either from artifacts url defined in eth_config or from contract_addresses
+    if contract_addresses is None:
         contract_addresses = fetch_hyperdrive_address_from_url(os.path.join(eth_config.ARTIFACTS_URL, "addresses.json"))
 
     if develop:  # setup env automatically & fund the agents

--- a/lib/agent0/agent0/hyperdrive/exec/run_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/run_agents.py
@@ -9,7 +9,7 @@ from agent0 import AccountKeyConfig
 from agent0.base.config import DEFAULT_USERNAME, AgentConfig, EnvironmentConfig
 from eth_typing import BlockNumber
 from ethpy import EthConfig, build_eth_config
-from ethpy.hyperdrive.addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_url
+from ethpy.hyperdrive import HyperdriveAddresses, fetch_hyperdrive_address_from_url
 
 from .create_and_fund_user_account import create_and_fund_user_account
 from .fund_agents import fund_agents

--- a/lib/agent0/agent0/test_fixtures/__init__.py
+++ b/lib/agent0/agent0/test_fixtures/__init__.py
@@ -1,0 +1,2 @@
+"""Test fixtures for agent0"""
+from .cycle_trade_policy import AgentDoneException, cycle_trade_policy

--- a/lib/agent0/agent0/test_fixtures/cycle_trade_policy.py
+++ b/lib/agent0/agent0/test_fixtures/cycle_trade_policy.py
@@ -28,10 +28,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
         budget: FixedPoint,
         rng: NumpyGenerator | None = None,
         slippage_tolerance: FixedPoint | None = None,
-        # Add additional parameters for custom policy here
-        static_trade_amount_wei: int = int(100e18),  # 100 base
     ):
-        self.static_trade_amount_wei = static_trade_amount_wei
         # We want to do a sequence of trades one at a time, so we keep an internal counter based on
         # how many times `action` has been called.
         self.counter = 0
@@ -47,7 +44,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                     market_type=MarketType.HYPERDRIVE,
                     market_action=HyperdriveMarketAction(
                         action_type=HyperdriveActionType.ADD_LIQUIDITY,
-                        trade_amount=FixedPoint(scaled_value=self.static_trade_amount_wei),
+                        trade_amount=FixedPoint(scaled_value=int(11111e18)),
                         wallet=wallet,
                     ),
                 )
@@ -59,7 +56,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                     market_type=MarketType.HYPERDRIVE,
                     market_action=HyperdriveMarketAction(
                         action_type=HyperdriveActionType.OPEN_LONG,
-                        trade_amount=FixedPoint(scaled_value=self.static_trade_amount_wei),
+                        trade_amount=FixedPoint(scaled_value=int(22222e18)),
                         wallet=wallet,
                     ),
                 )
@@ -71,7 +68,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                     market_type=MarketType.HYPERDRIVE,
                     market_action=HyperdriveMarketAction(
                         action_type=HyperdriveActionType.OPEN_SHORT,
-                        trade_amount=FixedPoint(scaled_value=self.static_trade_amount_wei),
+                        trade_amount=FixedPoint(scaled_value=int(33333e18)),
                         wallet=wallet,
                     ),
                 )
@@ -134,13 +131,14 @@ class CycleTradesPolicy(HyperdrivePolicy):
             )
         elif self.counter == 7:
             # One more dummy trade to ensure the previous trades get into the db
-            # TODO test if we can remove this eventually
+            # TODO test if we can remove this eventually by allowing acquire_data to look at
+            # current block
             action_list.append(
                 Trade(
                     market_type=MarketType.HYPERDRIVE,
                     market_action=HyperdriveMarketAction(
                         action_type=HyperdriveActionType.OPEN_LONG,
-                        trade_amount=FixedPoint(scaled_value=self.static_trade_amount_wei),
+                        trade_amount=FixedPoint(scaled_value=int(1e18)),
                         wallet=wallet,
                     ),
                 )

--- a/lib/agent0/agent0/test_fixtures/cycle_trade_policy.py
+++ b/lib/agent0/agent0/test_fixtures/cycle_trade_policy.py
@@ -104,7 +104,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                         ),
                     )
                 )
-        elif self.counter == 4:
+        elif self.counter == 5:
             # Close All Shorts
             assert len(wallet.shorts) == 1
             for short_time, short in wallet.shorts.items():
@@ -120,7 +120,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                         ),
                     )
                 )
-        elif self.counter == 5:
+        elif self.counter == 6:
             # Redeem all withdrawal shares
             action_list.append(
                 Trade(
@@ -132,7 +132,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                     ),
                 )
             )
-        elif self.counter == 6:
+        elif self.counter == 7:
             # One more dummy trade to ensure the previous trades get into the db
             # TODO test if we can remove this eventually
             action_list.append(

--- a/lib/agent0/agent0/test_fixtures/cycle_trade_policy.py
+++ b/lib/agent0/agent0/test_fixtures/cycle_trade_policy.py
@@ -1,0 +1,160 @@
+"""Pytest fixture that creates an in memory db session and creates dummy db schemas"""
+from __future__ import annotations
+
+from typing import Type
+
+import pytest
+from agent0.hyperdrive.agents import HyperdriveWallet
+from agent0.hyperdrive.policies import HyperdrivePolicy
+from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction
+from elfpy.markets.hyperdrive import HyperdriveMarket as HyperdriveMarketState
+from elfpy.types import MarketType, Trade
+from fixedpointmath import FixedPoint
+from numpy.random._generator import Generator as NumpyGenerator
+
+
+class AgentDoneException(Exception):
+    """Custom exception for signaling the bot is done"""
+
+    pass
+
+
+# Build custom policy
+# Simple agent, opens a set of all trades for a fixed amount and closes them after
+class CycleTradesPolicy(HyperdrivePolicy):
+    """A agent that simply cycles through all trades"""
+
+    # Using default parameters
+    def __init__(
+        self,
+        budget: FixedPoint,
+        rng: NumpyGenerator | None = None,
+        slippage_tolerance: FixedPoint | None = None,
+        # Add additional parameters for custom policy here
+        static_trade_amount_wei: int = int(100e18),  # 100 base
+    ):
+        self.static_trade_amount_wei = static_trade_amount_wei
+        # We want to do a sequence of trades one at a time, so we keep an internal counter based on
+        # how many times `action` has been called.
+        self.counter = 0
+        super().__init__(budget, rng, slippage_tolerance)
+
+    def action(self, market: HyperdriveMarketState, wallet: HyperdriveWallet) -> list[Trade[HyperdriveMarketAction]]:
+        """This agent simply opens all trades for a fixed amount and closes them after, one at a time"""
+        action_list = []
+        if self.counter == 0:
+            # Add liquidity
+            action_list.append(
+                Trade(
+                    market_type=MarketType.HYPERDRIVE,
+                    market_action=HyperdriveMarketAction(
+                        action_type=HyperdriveActionType.ADD_LIQUIDITY,
+                        trade_amount=FixedPoint(scaled_value=self.static_trade_amount_wei),
+                        wallet=wallet,
+                    ),
+                )
+            )
+        elif self.counter == 1:
+            # Open Long
+            action_list.append(
+                Trade(
+                    market_type=MarketType.HYPERDRIVE,
+                    market_action=HyperdriveMarketAction(
+                        action_type=HyperdriveActionType.OPEN_LONG,
+                        trade_amount=FixedPoint(scaled_value=self.static_trade_amount_wei),
+                        wallet=wallet,
+                    ),
+                )
+            )
+        elif self.counter == 2:
+            # Open Short
+            action_list.append(
+                Trade(
+                    market_type=MarketType.HYPERDRIVE,
+                    market_action=HyperdriveMarketAction(
+                        action_type=HyperdriveActionType.OPEN_SHORT,
+                        trade_amount=FixedPoint(scaled_value=self.static_trade_amount_wei),
+                        wallet=wallet,
+                    ),
+                )
+            )
+        elif self.counter == 3:
+            # Remove All Liquidity
+            action_list.append(
+                Trade(
+                    market_type=MarketType.HYPERDRIVE,
+                    market_action=HyperdriveMarketAction(
+                        action_type=HyperdriveActionType.REMOVE_LIQUIDITY,
+                        trade_amount=wallet.lp_tokens,
+                        wallet=wallet,
+                    ),
+                )
+            )
+        elif self.counter == 4:
+            # Close All Longs
+            assert len(wallet.longs) == 1
+            for long_time, long in wallet.longs.items():
+                action_list.append(
+                    Trade(
+                        market_type=MarketType.HYPERDRIVE,
+                        market_action=HyperdriveMarketAction(
+                            action_type=HyperdriveActionType.CLOSE_LONG,
+                            trade_amount=long.balance,
+                            wallet=wallet,
+                            # TODO is this actually maturity time? Not mint time?
+                            mint_time=long_time,
+                        ),
+                    )
+                )
+        elif self.counter == 4:
+            # Close All Shorts
+            assert len(wallet.shorts) == 1
+            for short_time, short in wallet.shorts.items():
+                action_list.append(
+                    Trade(
+                        market_type=MarketType.HYPERDRIVE,
+                        market_action=HyperdriveMarketAction(
+                            action_type=HyperdriveActionType.CLOSE_SHORT,
+                            trade_amount=short.balance,
+                            wallet=wallet,
+                            # TODO is this actually maturity time? Not mint time?
+                            mint_time=short_time,
+                        ),
+                    )
+                )
+        elif self.counter == 5:
+            # Redeem all withdrawal shares
+            action_list.append(
+                Trade(
+                    market_type=MarketType.HYPERDRIVE,
+                    market_action=HyperdriveMarketAction(
+                        action_type=HyperdriveActionType.REDEEM_WITHDRAW_SHARE,
+                        trade_amount=wallet.withdraw_shares,
+                        wallet=wallet,
+                    ),
+                )
+            )
+        elif self.counter == 6:
+            # One more dummy trade to ensure the previous trades get into the db
+            # TODO test if we can remove this eventually
+            action_list.append(
+                Trade(
+                    market_type=MarketType.HYPERDRIVE,
+                    market_action=HyperdriveMarketAction(
+                        action_type=HyperdriveActionType.OPEN_LONG,
+                        trade_amount=FixedPoint(scaled_value=self.static_trade_amount_wei),
+                        wallet=wallet,
+                    ),
+                )
+            )
+        else:
+            # We want this bot to exit and crash after it's done the trades it needs to do
+            raise AgentDoneException("Bot done")
+        self.counter += 1
+        return action_list
+
+
+@pytest.fixture(scope="function")
+def cycle_trade_policy() -> Type[CycleTradesPolicy]:
+    """Test fixture to build a policy that cycles through all trades"""
+    return CycleTradesPolicy

--- a/lib/agent0/agent0/test_fixtures/cycle_trade_policy.py
+++ b/lib/agent0/agent0/test_fixtures/cycle_trade_policy.py
@@ -16,8 +16,6 @@ from numpy.random._generator import Generator as NumpyGenerator
 class AgentDoneException(Exception):
     """Custom exception for signaling the bot is done"""
 
-    pass
-
 
 # Build custom policy
 # Simple agent, opens a set of all trades for a fixed amount and closes them after

--- a/lib/agent0/bin/fund_agents_from_user_key.py
+++ b/lib/agent0/bin/fund_agents_from_user_key.py
@@ -9,7 +9,7 @@ from agent0.hyperdrive.agents import HyperdriveAgent
 from agent0.hyperdrive.exec import fund_agents
 from eth_account.account import Account
 from ethpy import build_eth_config
-from ethpy.hyperdrive.addresses import fetch_hyperdrive_address_from_url
+from ethpy.hyperdrive import fetch_hyperdrive_address_from_url
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/lib/agent0/examples/example_agent.py
+++ b/lib/agent0/examples/example_agent.py
@@ -24,6 +24,9 @@ ENV_FILE = "example_agent.account.env"
 
 # Build custom policy
 # Simple agent, opens a set of all trades for a fixed amount and closes them after
+# TODO this bot is almost identical to the one defined in test_fixtures for system tests
+# On one hand, this bot is nice for an example since it shows all trades
+# On the other, duplicated code between the two bots
 class CycleTradesPolicy(HyperdrivePolicy):
     """An agent that simply cycles through all trades"""
 
@@ -109,7 +112,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                         ),
                     )
                 )
-        elif self.counter == 4:
+        elif self.counter == 5:
             # Close All Shorts
             assert len(wallet.shorts) == 1
             for short_time, short in wallet.shorts.items():
@@ -125,7 +128,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                         ),
                     )
                 )
-        elif self.counter == 5:
+        elif self.counter == 6:
             # Redeem all withdrawal shares
             action_list.append(
                 Trade(
@@ -137,7 +140,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                     ),
                 )
             )
-        elif self.counter == 6:
+        elif self.counter == 7:
             # One more dummy trade to ensure the previous trades get into the db
             # TODO test if we can remove this eventually
             action_list.append(

--- a/lib/chainsync/bin/run_chainsync.py
+++ b/lib/chainsync/bin/run_chainsync.py
@@ -5,13 +5,5 @@ from chainsync.exec import acquire_data
 from elfpy.utils import logs as log_utils
 
 if __name__ == "__main__":
-    # setup constants
-    START_BLOCK = 0
-    # Look back limit for backfilling
-    LOOKBACK_BLOCK_LIMIT = 100000
-
     log_utils.setup_logging(".logging/acquire_data.log", log_stdout=True)
-    acquire_data(
-        START_BLOCK,
-        LOOKBACK_BLOCK_LIMIT,
-    )
+    acquire_data()

--- a/lib/chainsync/bin/run_chainsync.py
+++ b/lib/chainsync/bin/run_chainsync.py
@@ -1,0 +1,24 @@
+"""Script to format on-chain hyperdrive pool, config, and transaction data post-processing."""
+from __future__ import annotations
+
+from chainsync.exec import acquire_data
+from elfpy.utils import logs as log_utils
+from ethpy import build_eth_config
+
+if __name__ == "__main__":
+    # setup constants
+    START_BLOCK = 0
+    # Look back limit for backfilling
+    LOOKBACK_BLOCK_LIMIT = 100000
+
+    # Load parameters from env vars if they exist
+    config = build_eth_config()
+
+    log_utils.setup_logging(".logging/acquire_data.log", log_stdout=True)
+    acquire_data(
+        config.ARTIFACTS_URL,
+        config.RPC_URL,
+        config.ABI_DIR,
+        START_BLOCK,
+        LOOKBACK_BLOCK_LIMIT,
+    )

--- a/lib/chainsync/bin/run_chainsync.py
+++ b/lib/chainsync/bin/run_chainsync.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from chainsync.exec import acquire_data
 from elfpy.utils import logs as log_utils
-from ethpy import build_eth_config
 
 if __name__ == "__main__":
     # setup constants
@@ -11,14 +10,8 @@ if __name__ == "__main__":
     # Look back limit for backfilling
     LOOKBACK_BLOCK_LIMIT = 100000
 
-    # Load parameters from env vars if they exist
-    config = build_eth_config()
-
     log_utils.setup_logging(".logging/acquire_data.log", log_stdout=True)
     acquire_data(
-        config.ARTIFACTS_URL,
-        config.RPC_URL,
-        config.ABI_DIR,
         START_BLOCK,
         LOOKBACK_BLOCK_LIMIT,
     )

--- a/lib/chainsync/bin/run_hyperdrive_dashboard.py
+++ b/lib/chainsync/bin/run_hyperdrive_dashboard.py
@@ -34,9 +34,6 @@ eth_config = build_eth_config()
 # pool config data is static, so just read once
 config_data = get_pool_config(session, coerce_float=False)
 
-# TODO fix input invTimeStretch to be unscaled in ingestion into postgres
-config_data["invTimeStretch"] = config_data["invTimeStretch"] / 10**18
-
 config_data = config_data.iloc[0]
 
 

--- a/lib/chainsync/chainsync/db/hyperdrive/convert_data.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/convert_data.py
@@ -565,7 +565,7 @@ def _build_hyperdrive_transaction_object(
         "transactionHash": transaction_dict["hash"],
         "txn_to": transaction_dict["to"],
         "txn_from": transaction_dict["from"],
-        "gasUsed": receipt["gasUsed"],
+        "gasUsed": _convert_scaled_value_to_decimal(receipt["gasUsed"]),
     }
     # Input solidity methods and parameters
     # TODO can the input field ever be empty or not exist?

--- a/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
@@ -187,7 +187,7 @@ class TestPoolConfigInterface:
         # Nothing should happen if we give the same pool_config
         # TODO Below is a hack due to sqlite not having numerics
         # We explicitly print 18 spots after floating point to match rounding error in sqlite
-        pool_config_2 = PoolConfig(contractAddress="0", initialSharePrice=Decimal("{:.18f}".format(3.2)))
+        pool_config_2 = PoolConfig(contractAddress="0", initialSharePrice=Decimal(f"{3.2:.18f}"))
         add_pool_config(pool_config_2, db_session)
         pool_config_df_2 = get_pool_config(db_session)
         assert len(pool_config_df_2) == 1

--- a/lib/chainsync/chainsync/db/hyperdrive/schema.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema.py
@@ -36,7 +36,7 @@ class PoolConfig(Base):
     oracleSize: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     updateGap: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
     invTimeStretch: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
-    termLength: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    updateGap: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
 
 
 class CheckpointInfo(Base):

--- a/lib/chainsync/chainsync/db/hyperdrive/schema.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema.py
@@ -210,7 +210,7 @@ class HyperdriveTransaction(Base):
     event_operator: Mapped[Union[str, None]] = mapped_column(String, default=None)
     event_id: Mapped[Union[int, None]] = mapped_column(
         Numeric, default=None
-    )  # Integer too small here to store event_id, so we use Numeric here instead
+    )  # Integer too small here to store event_id, so we use Numeric instead
     # Fields calculated from base
     event_prefix: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
     event_maturity_time: Mapped[Union[int, None]] = mapped_column(BigInteger, default=None)

--- a/lib/chainsync/chainsync/db/hyperdrive/schema.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema.py
@@ -91,7 +91,7 @@ class WalletInfo(Base):
     # tokenType is the baseTokenType appended with "-<maturity_time>" for LONG and SHORT
     tokenType: Mapped[Union[str, None]] = mapped_column(String, default=None)
     tokenValue: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    maturityTime: Mapped[Union[int, None]] = mapped_column(BigInteger().with_variant(Integer, "sqlite"), default=None)
+    maturityTime: Mapped[Union[int, None]] = mapped_column(BigInteger, default=None)
     sharePrice: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
 
 
@@ -115,7 +115,7 @@ class WalletDelta(Base):
     # tokenType is the baseTokenType appended with "-<maturity_time>" for LONG and SHORT
     tokenType: Mapped[Union[str, None]] = mapped_column(String, default=None)
     delta: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    maturityTime: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    maturityTime: Mapped[Union[int, None]] = mapped_column(BigInteger, default=None)
 
 
 class HyperdriveTransaction(Base):
@@ -168,7 +168,7 @@ class HyperdriveTransaction(Base):
     # input_params_asUnderlying
 
     # Method: closeLong
-    input_params_maturityTime: Mapped[Union[int, None]] = mapped_column(Numeric, default=None)
+    input_params_maturityTime: Mapped[Union[int, None]] = mapped_column(BigInteger, default=None)
     # input_params_bondAmount
     # input_params_minOutput
     # input_params_destination
@@ -206,7 +206,7 @@ class HyperdriveTransaction(Base):
     event_id: Mapped[Union[int, None]] = mapped_column(Numeric, default=None)
     # Fields calculated from base
     event_prefix: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
-    event_maturity_time: Mapped[Union[int, None]] = mapped_column(Numeric, default=None)
+    event_maturity_time: Mapped[Union[int, None]] = mapped_column(BigInteger, default=None)
 
     # Fields not used by postprocessing
 

--- a/lib/chainsync/chainsync/db/hyperdrive/schema.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema.py
@@ -10,6 +10,9 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 # pylint: disable=invalid-name
 
+# Postgres numeric type that matches fixedpoint
+FIXED_NUMERIC = Numeric(precision=1000, scale=18)
+
 
 class PoolConfig(Base):
     """Table/dataclass schema for pool config."""
@@ -18,20 +21,20 @@ class PoolConfig(Base):
 
     contractAddress: Mapped[str] = mapped_column(String, primary_key=True)
     baseToken: Mapped[Union[str, None]] = mapped_column(String, default=None)
-    initialSharePrice: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    minimumShareReserves: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    initialSharePrice: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    minimumShareReserves: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     positionDuration: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
     checkpointDuration: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
-    timeStretch: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    timeStretch: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     governance: Mapped[Union[str, None]] = mapped_column(String, default=None)
     feeCollector: Mapped[Union[str, None]] = mapped_column(String, default=None)
-    curveFee: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    flatFee: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    governanceFee: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    oracleSize: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    curveFee: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    flatFee: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    governanceFee: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    oracleSize: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     updateGap: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
-    invTimeStretch: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    termLength: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    invTimeStretch: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    termLength: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
 
 
 class CheckpointInfo(Base):
@@ -41,9 +44,9 @@ class CheckpointInfo(Base):
 
     blockNumber: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     timestamp: Mapped[datetime] = mapped_column(DateTime, index=True)
-    sharePrice: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    longSharePrice: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    shortBaseVolume: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    sharePrice: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    longSharePrice: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    shortBaseVolume: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
 
 
 class PoolInfo(Base):
@@ -56,19 +59,19 @@ class PoolInfo(Base):
 
     blockNumber: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     timestamp: Mapped[datetime] = mapped_column(DateTime, index=True)
-    shareReserves: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    bondReserves: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    lpTotalSupply: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    sharePrice: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    lpSharePrice: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    longsOutstanding: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    longAverageMaturityTime: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    shortsOutstanding: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    shortAverageMaturityTime: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    shortBaseVolume: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    withdrawalSharesReadyToWithdraw: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    withdrawalSharesProceeds: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    totalSupplyWithdrawalShares: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    shareReserves: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    bondReserves: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    lpTotalSupply: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    sharePrice: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    lpSharePrice: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    longsOutstanding: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    longAverageMaturityTime: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    shortsOutstanding: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    shortAverageMaturityTime: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    shortBaseVolume: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    withdrawalSharesReadyToWithdraw: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    withdrawalSharesProceeds: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    totalSupplyWithdrawalShares: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
 
 
 # TODO: Rename this to something more accurate to what is happening, e.g. HyperdriveTransactions
@@ -90,9 +93,9 @@ class WalletInfo(Base):
     baseTokenType: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
     # tokenType is the baseTokenType appended with "-<maturity_time>" for LONG and SHORT
     tokenType: Mapped[Union[str, None]] = mapped_column(String, default=None)
-    tokenValue: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    tokenValue: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     maturityTime: Mapped[Union[int, None]] = mapped_column(BigInteger, default=None)
-    sharePrice: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    sharePrice: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
 
 
 # TODO: either make a more general TokenDelta, or rename this to HyperdriveDelta
@@ -114,7 +117,7 @@ class WalletDelta(Base):
     baseTokenType: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
     # tokenType is the baseTokenType appended with "-<maturity_time>" for LONG and SHORT
     tokenType: Mapped[Union[str, None]] = mapped_column(String, default=None)
-    delta: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    delta: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     maturityTime: Mapped[Union[int, None]] = mapped_column(BigInteger, default=None)
 
 
@@ -142,7 +145,7 @@ class HyperdriveTransaction(Base):
     # Almost always from wallet address to smart contract address
     txn_to: Mapped[Union[str, None]] = mapped_column(String, default=None)
     txn_from: Mapped[Union[str, None]] = mapped_column(String, default=None)
-    gasUsed: Mapped[Union[int, None]] = mapped_column(Numeric, default=None)
+    gasUsed: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
 
     #### Fields from solidity function calls ####
     # These fields map solidity function calls and their corresponding arguments
@@ -150,20 +153,20 @@ class HyperdriveTransaction(Base):
     input_method: Mapped[Union[str, None]] = mapped_column(String, default=None)
 
     # Method: initialize
-    input_params_contribution: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    input_params_apr: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    input_params_contribution: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    input_params_apr: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     input_params_destination: Mapped[Union[str, None]] = mapped_column(String, default=None)
     input_params_asUnderlying: Mapped[Union[bool, None]] = mapped_column(Boolean, default=None)
 
     # Method: openLong
-    input_params_baseAmount: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    input_params_minOutput: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    input_params_baseAmount: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    input_params_minOutput: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     # input_params_destination
     # input_params_asUnderlying
 
     # Method: openShort
-    input_params_bondAmount: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    input_params_maxDeposit: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    input_params_bondAmount: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    input_params_maxDeposit: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     # input_params_destination
     # input_params_asUnderlying
 
@@ -183,13 +186,13 @@ class HyperdriveTransaction(Base):
 
     # Method: addLiquidity
     # input_params_contribution
-    input_params_minApr: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
-    input_params_maxApr: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    input_params_minApr: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    input_params_maxApr: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     # input_params_destination
     # input_params_asUnderlying
 
     # Method: removeLiquidity
-    input_params_shares: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    input_params_shares: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     # input_params_minOutput
     # input_params_destination
     # input_params_asUnderlying
@@ -201,9 +204,11 @@ class HyperdriveTransaction(Base):
     # args_owner
     # args_spender
     # args_id
-    event_value: Mapped[Union[Decimal, None]] = mapped_column(Numeric, default=None)
+    event_value: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     event_operator: Mapped[Union[str, None]] = mapped_column(String, default=None)
-    event_id: Mapped[Union[int, None]] = mapped_column(Numeric, default=None)
+    event_id: Mapped[Union[int, None]] = mapped_column(
+        Numeric, default=None
+    )  # Integer too small here to store event_id, so we use Numeric here instead
     # Fields calculated from base
     event_prefix: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
     event_maturity_time: Mapped[Union[int, None]] = mapped_column(BigInteger, default=None)

--- a/lib/chainsync/chainsync/db/hyperdrive/schema.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema.py
@@ -11,6 +11,8 @@ from sqlalchemy.orm import Mapped, mapped_column
 # pylint: disable=invalid-name
 
 # Postgres numeric type that matches fixedpoint
+# The high precision doesn't actually allocate memory in postgres, as numeric is variable size
+# https://stackoverflow.com/questions/40686571/performance-of-numeric-type-with-high-precisions-and-scales-in-postgresql
 FIXED_NUMERIC = Numeric(precision=1000, scale=18)
 
 

--- a/lib/chainsync/chainsync/db/hyperdrive/schema.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema.py
@@ -11,6 +11,8 @@ from sqlalchemy.orm import Mapped, mapped_column
 # pylint: disable=invalid-name
 
 # Postgres numeric type that matches fixedpoint
+# Precision here indicates the total number of significant digits to store,
+# while scale indicates the number of digits to the right of the decimal
 # The high precision doesn't actually allocate memory in postgres, as numeric is variable size
 # https://stackoverflow.com/questions/40686571/performance-of-numeric-type-with-high-precisions-and-scales-in-postgresql
 FIXED_NUMERIC = Numeric(precision=1000, scale=18)

--- a/lib/chainsync/chainsync/exec/__init__.py
+++ b/lib/chainsync/chainsync/exec/__init__.py
@@ -1,0 +1,1 @@
+from .acquire_data import acquire_data

--- a/lib/chainsync/chainsync/exec/__init__.py
+++ b/lib/chainsync/chainsync/exec/__init__.py
@@ -1,1 +1,2 @@
+"""Execution functions for chainsync"""
 from .acquire_data import acquire_data

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -40,9 +40,12 @@ def acquire_data(
     eth_config: EthConfig | None
         Configuration for urls to the rpc and artifacts. If not set, will look for addresses
         in eth.env.
-    overwrite_db_session: Session | None
+    db_session: Session | None
         Session object for connecting to db. If None, will initialize a new session based on
         postgres.env.
+    contract_addresses: HyperdriveAddresses | None
+        If set, will use these addresses instead of querying the artifact url
+        defined in eth_config.
     exit_on_catch_up: bool
         If True, will exit after catching up to current block
     """

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -16,6 +16,7 @@ from eth_utils import address
 from ethpy.base import initialize_web3_with_http_provider, load_all_abis
 from ethpy.hyperdrive import fetch_hyperdrive_address_from_url
 from ethpy.hyperdrive.interface import get_hyperdrive_contract
+from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.contract.contract import Contract
 

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -12,14 +12,9 @@ from chainsync.db.hyperdrive import (
     init_data_chain_to_db,
 )
 from eth_typing import BlockNumber
-from eth_utils import address
 from ethpy import EthConfig, build_eth_config
-from ethpy.base import initialize_web3_with_http_provider, load_all_abis
-from ethpy.hyperdrive import fetch_hyperdrive_address_from_url, get_web3_and_hyperdrive_contracts
-from ethpy.hyperdrive.interface import get_hyperdrive_contract
+from ethpy.hyperdrive import get_web3_and_hyperdrive_contracts
 from sqlalchemy.orm import Session
-from web3 import Web3
-from web3.contract.contract import Contract
 
 _SLEEP_AMOUNT = 1
 
@@ -27,7 +22,7 @@ _SLEEP_AMOUNT = 1
 def acquire_data(
     start_block: int,
     lookback_block_limit: int,
-    eth_config: EthConfig | None,
+    eth_config: EthConfig | None = None,
     overwrite_db_session: Session | None = None,
 ):
     """Execute the data acquisition pipeline.

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 
 from chainsync.db.base import initialize_session
@@ -12,17 +13,21 @@ from chainsync.db.hyperdrive import (
 )
 from eth_typing import BlockNumber
 from ethpy import EthConfig, build_eth_config
-from ethpy.hyperdrive import get_web3_and_hyperdrive_contracts
+from ethpy.hyperdrive import HyperdriveAddresses, fetch_hyperdrive_address_from_url, get_web3_and_hyperdrive_contracts
 from sqlalchemy.orm import Session
 
 _SLEEP_AMOUNT = 1
 
 
+# Lots of arguments
+# pylint: disable=too-many-arguments
 def acquire_data(
-    start_block: int,
-    lookback_block_limit: int,
+    start_block: int = 0,
+    lookback_block_limit: int = 10000,
     eth_config: EthConfig | None = None,
-    overwrite_db_session: Session | None = None,
+    db_session: Session | None = None,
+    contract_addresses: HyperdriveAddresses | None = None,
+    exit_on_catch_up: bool = False,
 ):
     """Execute the data acquisition pipeline.
 
@@ -38,6 +43,8 @@ def acquire_data(
     overwrite_db_session: Session | None
         Session object for connecting to db. If None, will initialize a new session based on
         postgres.env.
+    exit_on_catch_up: bool
+        If True, will exit after catching up to current block
     """
     ## Initialization
     # eth config
@@ -46,17 +53,19 @@ def acquire_data(
         eth_config = build_eth_config()
 
     # postgres session
-    if overwrite_db_session is not None:
-        session = overwrite_db_session
-    else:
-        session = initialize_session()
+    if db_session is None:
+        db_session = initialize_session()
+
+    # Get addresses either from artifacts url defined in eth_config or from contract_addresses
+    if contract_addresses is None:
+        contract_addresses = fetch_hyperdrive_address_from_url(os.path.join(eth_config.ARTIFACTS_URL, "addresses.json"))
 
     # Get web3 and contracts
-    web3, base_contract, hyperdrive_contract = get_web3_and_hyperdrive_contracts(eth_config)
+    web3, base_contract, hyperdrive_contract = get_web3_and_hyperdrive_contracts(eth_config, contract_addresses)
 
     ## Get starting point for restarts
     # Get last entry of pool info in db
-    data_latest_block_number = get_latest_block_number_from_pool_info_table(session)
+    data_latest_block_number = get_latest_block_number_from_pool_info_table(db_session)
     # Using max of latest block in database or specified start block
     block_number: BlockNumber = BlockNumber(max(start_block, data_latest_block_number))
     # Make sure to not grab current block, as the current block is subject to change
@@ -69,11 +78,11 @@ def acquire_data(
         logging.warning("Starting block is past lookback block limit, starting at block %s", block_number)
 
     # Collect initial data
-    init_data_chain_to_db(hyperdrive_contract, session)
+    init_data_chain_to_db(hyperdrive_contract, db_session)
     # This if statement executes only on initial run (based on data_latest_block_number check),
     # and if the chain has executed until start_block (based on latest_mined_block check)
     if data_latest_block_number < block_number < latest_mined_block:
-        data_chain_to_db(web3, base_contract, hyperdrive_contract, block_number, session)
+        data_chain_to_db(web3, base_contract, hyperdrive_contract, block_number, db_session)
 
     # Main data loop
     # monitor for new blocks & add pool info per block
@@ -83,6 +92,8 @@ def acquire_data(
         # Only execute if we are on a new block
         if latest_mined_block <= block_number:
             time.sleep(_SLEEP_AMOUNT)
+            if exit_on_catch_up:
+                break
             continue
         # Backfilling for blocks that need updating
         for block_int in range(block_number + 1, latest_mined_block + 1):
@@ -96,5 +107,5 @@ def acquire_data(
                     latest_mined_block,
                 )
                 continue
-            data_chain_to_db(web3, base_contract, hyperdrive_contract, block_number, session)
+            data_chain_to_db(web3, base_contract, hyperdrive_contract, block_number, db_session)
         time.sleep(_SLEEP_AMOUNT)

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 
 from chainsync.db.base import initialize_session

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -2,6 +2,7 @@
 from .addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_url
 from .assets import AssetIdPrefix, decode_asset_id, encode_asset_id
 from .errors import HyperdriveErrors, lookup_hyperdrive_error_selector
+from .get_web3_and_hyperdrive_contracts import get_web3_and_hyperdrive_contracts
 from .interface import (
     get_hyperdrive_checkpoint_info,
     get_hyperdrive_config,

--- a/lib/ethpy/ethpy/hyperdrive/get_web3_and_hyperdrive_contracts.py
+++ b/lib/ethpy/ethpy/hyperdrive/get_web3_and_hyperdrive_contracts.py
@@ -1,0 +1,53 @@
+"""Helper function for getting web3 and contracts."""
+from __future__ import annotations
+
+import os
+
+from ethpy import EthConfig
+from ethpy.base import initialize_web3_with_http_provider, load_all_abis
+from web3 import Web3
+from web3.contract.contract import Contract
+
+from .addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_url
+
+
+def get_web3_and_hyperdrive_contracts(
+    eth_config: EthConfig, contract_addresses: HyperdriveAddresses | None = None
+) -> tuple[Web3, Contract, Contract]:
+    """Get the web3 container and the ERC20Base and Hyperdrive contracts.
+
+    Arguments
+    ---------
+    eth_config: EthConfig
+        Configuration for urls to the rpc and artifacts.
+    contract_addresses: HyperdriveAddresses | None
+        Configuration for defining various contract addresses.
+        Will query eth_config artifacts for addresses by default
+
+    Returns
+    -------
+    tuple[Web3, Contract, Contract]
+        A tuple containing:
+            - The web3 container
+            - The base token contract
+            - The hyperdrive contract
+    """
+    # Initialize contract addresses if none
+    if contract_addresses is None:
+        contract_addresses = fetch_hyperdrive_address_from_url(os.path.join(eth_config.ARTIFACTS_URL, "addresses.json"))
+
+    # point to chain env
+    web3 = initialize_web3_with_http_provider(eth_config.RPC_URL, reset_provider=False)
+    # setup base contract interface
+    abis = load_all_abis(eth_config.ABI_DIR)
+    # set up the ERC20 contract for minting base tokens
+    # TODO is there a better way to pass in base and hyperdrive abi?
+    base_token_contract: Contract = web3.eth.contract(
+        abi=abis["ERC20Mintable"], address=web3.to_checksum_address(contract_addresses.base_token)
+    )
+    # set up hyperdrive contract
+    hyperdrive_contract: Contract = web3.eth.contract(
+        abi=abis["IHyperdrive"],
+        address=web3.to_checksum_address(contract_addresses.mock_hyperdrive),
+    )
+    return web3, base_token_contract, hyperdrive_contract

--- a/lib/ethpy/ethpy/hyperdrive/interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface.py
@@ -113,10 +113,9 @@ def get_hyperdrive_config(hyperdrive_contract: Contract) -> dict[str, Any]:
     pool_config["minimumShareReserves"] = FixedPoint(scaled_value=hyperdrive_config["minimumShareReserves"])
     pool_config["positionDuration"] = hyperdrive_config["positionDuration"]
     pool_config["checkpointDuration"] = hyperdrive_config["checkpointDuration"]
-    # Ok so, the contracts store the time stretch constant in an inverted manner from the python.
+    # TODO Ok so, the contracts store the time stretch constant in an inverted manner from the python.
     # In order to not break the world, we save the contract version as 'invTimeStretch' and invert
-    # that to get the python version 'timeStretch'
-    # TODO fix this
+    # that to get the python version 'timeStretch'. Fix this issue to match solidity
     pool_config["invTimeStretch"] = FixedPoint(scaled_value=hyperdrive_config["timeStretch"])
     pool_config["timeStretch"] = FixedPoint(1) / pool_config["invTimeStretch"]
     pool_config["governance"] = hyperdrive_config["governance"]

--- a/lib/ethpy/ethpy/hyperdrive/interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface.py
@@ -116,6 +116,7 @@ def get_hyperdrive_config(hyperdrive_contract: Contract) -> dict[str, Any]:
     # Ok so, the contracts store the time stretch constant in an inverted manner from the python.
     # In order to not break the world, we save the contract version as 'invTimeStretch' and invert
     # that to get the python version 'timeStretch'
+    # TODO fix this
     pool_config["invTimeStretch"] = FixedPoint(scaled_value=hyperdrive_config["timeStretch"])
     pool_config["timeStretch"] = FixedPoint(1) / pool_config["invTimeStretch"]
     pool_config["governance"] = hyperdrive_config["governance"]

--- a/lib/ethpy/ethpy/hyperdrive/interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface.py
@@ -116,9 +116,8 @@ def get_hyperdrive_config(hyperdrive_contract: Contract) -> dict[str, Any]:
     # Ok so, the contracts store the time stretch constant in an inverted manner from the python.
     # In order to not break the world, we save the contract version as 'invTimeStretch' and invert
     # that to get the python version 'timeStretch'
-    # TODO invTimeStretch should be in fixed point notation
-    pool_config["invTimeStretch"] = hyperdrive_config["timeStretch"]
-    pool_config["timeStretch"] = FixedPoint(1) / FixedPoint(scaled_value=hyperdrive_config["timeStretch"])
+    pool_config["invTimeStretch"] = FixedPoint(scaled_value=hyperdrive_config["timeStretch"])
+    pool_config["timeStretch"] = FixedPoint(1) / pool_config["invTimeStretch"]
     pool_config["governance"] = hyperdrive_config["governance"]
     pool_config["feeCollector"] = hyperdrive_config["feeCollector"]
     curve_fee, flat_fee, governance_fee = hyperdrive_config["fees"]

--- a/lib/ethpy/ethpy/test_fixtures/__init__.py
+++ b/lib/ethpy/ethpy/test_fixtures/__init__.py
@@ -1,2 +1,2 @@
 """Test fixtures for ethpy"""
-from .local_chain import hyperdrive_contract_addresses, local_chain
+from .local_chain import local_chain, local_hyperdrive_chain

--- a/lib/ethpy/ethpy/test_fixtures/__init__.py
+++ b/lib/ethpy/ethpy/test_fixtures/__init__.py
@@ -1,2 +1,2 @@
 """Test fixtures for ethpy"""
-from .local_chain import hyperdrive_contract_address, local_chain
+from .local_chain import hyperdrive_contract_addresses, local_chain

--- a/lib/ethpy/ethpy/test_fixtures/deploy_hyperdrive.py
+++ b/lib/ethpy/ethpy/test_fixtures/deploy_hyperdrive.py
@@ -84,10 +84,10 @@ def deploy_hyperdrive_factory(rpc_url: str, deploy_account: LocalAccount) -> tup
     initial_variable_rate = int(0.05e18)
     curve_fee = int(0.1e18)  # 10%
     flat_fee = int(0.0005e18)  # 0.05%
-    governance_fee = int(0.15e18)  # 0.15%
+    governance_fee = int(0.15e18)  # 15%
     max_curve_fee = int(0.3e18)  # 30%
     max_flat_fee = int(0.0015e18)  # 0.15%
-    max_governance_fee = int(0.30e18)  # 0.30%
+    max_governance_fee = int(0.30e18)  # 30%
     # Configuration settings
     abi_folder = "packages/hyperdrive/src/abis/"
 

--- a/lib/ethpy/ethpy/test_fixtures/local_chain.py
+++ b/lib/ethpy/ethpy/test_fixtures/local_chain.py
@@ -5,7 +5,7 @@ from typing import Any, Generator
 
 import pytest
 from ethpy.base import initialize_web3_with_http_provider
-from ethpy.hyperdrive.addresses import HyperdriveAddresses
+from ethpy.hyperdrive import HyperdriveAddresses
 from web3 import Web3
 
 from .deploy_hyperdrive import deploy_and_initialize_hyperdrive, deploy_hyperdrive_factory, initialize_deploy_account

--- a/lib/ethpy/ethpy/test_fixtures/local_chain.py
+++ b/lib/ethpy/ethpy/test_fixtures/local_chain.py
@@ -5,6 +5,8 @@ from typing import Any, Generator
 
 import pytest
 from ethpy.base import initialize_web3_with_http_provider
+from ethpy.hyperdrive.addresses import HyperdriveAddresses
+from web3 import Web3
 
 from .deploy_hyperdrive import deploy_and_initialize_hyperdrive, deploy_hyperdrive_factory, initialize_deploy_account
 
@@ -41,7 +43,7 @@ def local_chain() -> Generator[str, Any, Any]:
 
 
 @pytest.fixture(scope="function")
-def hyperdrive_contract_address(local_chain: str) -> str:
+def hyperdrive_contract_addresses(local_chain: str) -> HyperdriveAddresses:
     """Initializes hyperdrive on a local anvil chain for testing.
     Returns the hyperdrive contract address.
 
@@ -49,4 +51,11 @@ def hyperdrive_contract_address(local_chain: str) -> str:
     web3 = initialize_web3_with_http_provider(local_chain, reset_provider=False)
     account = initialize_deploy_account(web3)
     base_token_contract, factory_contract = deploy_hyperdrive_factory(local_chain, account)
-    return deploy_and_initialize_hyperdrive(web3, base_token_contract, factory_contract, account)
+    hyperdrive_addr = deploy_and_initialize_hyperdrive(web3, base_token_contract, factory_contract, account)
+
+    return HyperdriveAddresses(
+        base_token=Web3.to_checksum_address(base_token_contract.address),
+        hyperdrive_factory=Web3.to_checksum_address(factory_contract.address),
+        mock_hyperdrive=Web3.to_checksum_address(hyperdrive_addr),
+        mock_hyperdrive_math="not_used",
+    )

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -57,6 +57,7 @@ class TestBotToDb:
     """Tests pipeline from bots making trades to viewing the trades in the db"""
 
     # TODO split this up into different functions that work with tests
+    # pylint: disable=too-many-locals, too-many-statements
     def test_bot_to_db(
         self,
         local_chain: str,

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -1,17 +1,105 @@
 """System test for end to end testing of elf-simulations"""
+import logging
+from typing import Type
+
+from agent0 import build_account_key_config_from_agent_config
+from agent0.base.config import AgentConfig, EnvironmentConfig
+from agent0.base.policies import BasePolicy
+from agent0.hyperdrive.exec import run_agents
+from ethpy import EthConfig
+from ethpy.hyperdrive.addresses import HyperdriveAddresses
+from fixedpointmath import FixedPoint
+from sqlalchemy.orm import Session
+
+# This pass is to prevent auto reordering imports from reordering the imports below
+pass  # pylint: disable=unnecessary-pass
+
+# Test fixture imports
+# Ignoring unused import warning, fixtures are used through variable name
+from agent0.test_fixtures import (  # pylint: disable=unused-import, ungrouped-imports
+    AgentDoneException,
+    cycle_trade_policy,
+)
 from chainsync.test_fixtures import db_session  # pylint: disable=unused-import
-from ethpy.test_fixtures import hyperdrive_contract_address, local_chain  # pylint: disable=unused-import
+from ethpy.test_fixtures import (  # pylint: disable=unused-import, ungrouped-imports
+    hyperdrive_contract_addresses,
+    local_chain,
+)
 
 # fixture arguments in test function have to be the same as the fixture name
 # pylint: disable=redefined-outer-name
 
 
 class TestLocalChain:
-    """CRUD tests for checkpoint table"""
+    """Tests bringing up local chain"""
 
     # This is using 2 fixtures. Since hyperdrive_contract_address depends on local_chain, we need both here
     # This is due to adding test fixtures through imports
-    def test_hyperdrive_init_and_deploy(self, local_chain, hyperdrive_contract_address):
+    def test_hyperdrive_init_and_deploy(self, local_chain: str, hyperdrive_contract_addresses: HyperdriveAddresses):
         """Create and entry"""
         print(local_chain)
-        print(hyperdrive_contract_address)
+        print(hyperdrive_contract_addresses)
+
+
+class TestBotToDb:
+    """Tests pipeline from bots making trades to viewing the trades in the db"""
+
+    # This is using 3 fixtures
+    def test_bot_to_db(
+        self,
+        local_chain: str,
+        hyperdrive_contract_addresses: HyperdriveAddresses,
+        cycle_trade_policy: Type[BasePolicy],
+        db_session: Session,
+    ):
+        # Build environment config
+        env_config = EnvironmentConfig(
+            delete_previous_logs=False,
+            halt_on_errors=True,
+            log_filename="system_test",
+            log_level=logging.INFO,
+            log_stdout=True,
+            random_seed=1234,
+            username="test",
+        )
+
+        # Build agent config
+        agent_config: list[AgentConfig] = [
+            AgentConfig(
+                policy=cycle_trade_policy,
+                number_of_agents=1,
+                slippage_tolerance=FixedPoint(0.0001),
+                base_budget_wei=int(10_000e18),  # 10k base
+                eth_budget_wei=int(10e18),  # 10 base
+                init_kwargs={"static_trade_amount_wei": int(100e18)},  # 100 base static trades
+            ),
+        ]
+
+        # No need for random seed, this bot is deterministic
+        account_key_config = build_account_key_config_from_agent_config(agent_config)
+
+        # Build custom eth config pointing to local chain
+        eth_config = EthConfig(
+            # Artifacts_url isn't used here, as we explicitly set addresses and passed to run_bots
+            RPC_URL=local_chain,
+            # Default abi dir
+        )
+
+        # Run bots
+        try:
+            run_agents(
+                env_config,
+                agent_config,
+                account_key_config,
+                develop=True,
+                eth_config=eth_config,
+                override_addresses=hyperdrive_contract_addresses,
+            )
+        except AgentDoneException:
+            # Using this exception to stop the agents,
+            # so this exception is expected on test pass
+            pass
+
+        # Run acquire data to get data from chain to db
+
+        # TODO ensure all trades are in the db

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -10,11 +10,13 @@ from agent0.base.policies import BasePolicy
 from agent0.hyperdrive.exec import run_agents
 from chainsync.db.hyperdrive.interface import get_pool_config
 from chainsync.exec import acquire_data
+from eth_account.signers.local import LocalAccount
 from ethpy import EthConfig
 from ethpy.hyperdrive import HyperdriveAddresses
 from ethpy.test_fixtures.deploy_hyperdrive import _calculateTimeStretch
 from fixedpointmath import FixedPoint
 from sqlalchemy.orm import Session
+from web3 import Web3
 
 # This pass is to prevent auto reordering imports from reordering the imports below
 pass  # pylint: disable=unnecessary-pass
@@ -26,10 +28,7 @@ from agent0.test_fixtures import (  # pylint: disable=unused-import, ungrouped-i
     cycle_trade_policy,
 )
 from chainsync.test_fixtures import db_session  # pylint: disable=unused-import
-from ethpy.test_fixtures import (  # pylint: disable=unused-import, ungrouped-imports
-    hyperdrive_contract_addresses,
-    local_chain,
-)
+from ethpy.test_fixtures import local_chain, local_hyperdrive_chain  # pylint: disable=unused-import, ungrouped-imports
 
 # fixture arguments in test function have to be the same as the fixture name
 # pylint: disable=redefined-outer-name
@@ -40,10 +39,10 @@ class TestLocalChain:
 
     # This is using 2 fixtures. Since hyperdrive_contract_address depends on local_chain, we need both here
     # This is due to adding test fixtures through imports
-    def test_hyperdrive_init_and_deploy(self, local_chain: str, hyperdrive_contract_addresses: HyperdriveAddresses):
+    def test_hyperdrive_init_and_deploy(self, local_chain: str, local_hyperdrive_chain: dict):
         """Create and entry"""
         print(local_chain)
-        print(hyperdrive_contract_addresses)
+        print(local_hyperdrive_chain)
 
 
 def _to_unscaled_decimal(scaled_value: int) -> Decimal:
@@ -53,14 +52,19 @@ def _to_unscaled_decimal(scaled_value: int) -> Decimal:
 class TestBotToDb:
     """Tests pipeline from bots making trades to viewing the trades in the db"""
 
-    # This is using 3 fixtures
+    # TODO split this up into different functions that work with tests
     def test_bot_to_db(
         self,
         local_chain: str,
-        hyperdrive_contract_addresses: HyperdriveAddresses,
+        local_hyperdrive_chain: dict,
         cycle_trade_policy: Type[BasePolicy],
         db_session: Session,
     ):
+        # Get hyperdrive chain info
+        web3: Web3 = local_hyperdrive_chain["web3"]
+        deploy_account: LocalAccount = local_hyperdrive_chain["deploy_account"]
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain["hyperdrive_contract_addresses"]
+
         # Build environment config
         env_config = EnvironmentConfig(
             delete_previous_logs=False,
@@ -122,7 +126,7 @@ class TestBotToDb:
 
         # Test db entries are what we expect
         # We don't coerce to float because we want exact values in decimal
-        db_pool_config = get_pool_config(db_session, coerce_float=False)
+        db_pool_config_df: pd.DataFrame = get_pool_config(db_session, coerce_float=False)
 
         # TODO these expected values are defined in lib/ethpy/ethpy/test_fixtures/deploy_hyperdrive.py
         # Eventually, we want to parameterize these values to pass into deploying hyperdrive
@@ -131,22 +135,47 @@ class TestBotToDb:
         expected_timestretch = _to_unscaled_decimal((1 / expected_timestretch_fp).scaled_value)
         expected_inv_timestretch = _to_unscaled_decimal(expected_timestretch_fp.scaled_value)
 
-        expected_pool_config = pd.Series(
-            {
-                "contractAddress": hyperdrive_contract_addresses.mock_hyperdrive,
-                "baseToken": hyperdrive_contract_addresses.base_token,
-                "initialSharePrice": _to_unscaled_decimal(int(1e18)),
-                "minimumShareReserves": _to_unscaled_decimal(int(10e18)),
-                "positionDuration": 604800,  # 1 week
-                "checkpointDuration": 3600,  # 1 hour
-                # TODO this is actually inv of solidity time stretch, fix
-                "timeStretch": expected_timestretch,
-                # "governance":
-                # "feeCollector":
-                "invTimeStretch": expected_timestretch,
-            }
-        )
+        expected_values = {
+            "contractAddress": hyperdrive_contract_addresses.mock_hyperdrive,
+            "baseToken": hyperdrive_contract_addresses.base_token,
+            "initialSharePrice": _to_unscaled_decimal(int(1e18)),
+            "minimumShareReserves": _to_unscaled_decimal(int(10e18)),
+            "positionDuration": 604800,  # 1 week
+            "checkpointDuration": 3600,  # 1 hour
+            # TODO this is actually inv of solidity time stretch, fix
+            "timeStretch": expected_timestretch,
+            "governance": deploy_account.address,
+            "feeCollector": deploy_account.address,
+            "curveFee": _to_unscaled_decimal(int(0.1e18)),  # 10%
+            "flatFee": _to_unscaled_decimal(int(0.0005e18)),  # 0.05%
+            "governanceFee": _to_unscaled_decimal(int(0.15e18)),  # 15%
+            "oracleSize": _to_unscaled_decimal(10),
+            "updateGap": 3600,  # TODO don't know where this is getting set
+            "invTimeStretch": expected_inv_timestretch,
+        }
 
-        # TODO timestretch has rounding error
+        # Existence test
+        assert len(db_pool_config_df) == 1, "DB must have one entry for pool config"
+        db_pool_config: pd.Series = db_pool_config_df.iloc[0]
+
+        # Ensure keys match
+        # Converting to sets and compare
+        db_keys = set(db_pool_config.index)
+        expected_keys = set(expected_values.keys())
+        assert db_keys == expected_keys, "Keys in db do not match expected"
+
+        # Value comparison
+        for key, expected_value in expected_values.items():
+            # TODO In testing, we use sqlite, which does not implement the fixed point Numeric type
+            # Internally, they store Numeric types as floats, hence we see rounding errors in testing
+            # This does not happen in postgres, where these values match exactly.
+            # https://github.com/delvtech/elf-simulations/issues/836
+
+            if isinstance(expected_value, Decimal):
+                assert_val = abs(db_pool_config[key] - expected_value) < 1e-12
+            else:
+                assert_val = db_pool_config[key] == expected_value
+
+            assert assert_val, f"Values do not match for {key} ({db_pool_config[key]} != {expected_value})"
 
         # Ensure all trades are in the db

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -17,7 +17,6 @@ from ethpy.hyperdrive import HyperdriveAddresses
 from ethpy.test_fixtures.deploy_hyperdrive import _calculateTimeStretch
 from fixedpointmath import FixedPoint
 from sqlalchemy.orm import Session
-from web3 import Web3
 
 # This pass is to prevent auto reordering imports from reordering the imports below
 pass  # pylint: disable=unnecessary-pass
@@ -28,7 +27,7 @@ from agent0.test_fixtures import (  # pylint: disable=unused-import, ungrouped-i
     AgentDoneException,
     cycle_trade_policy,
 )
-from chainsync.test_fixtures import db_session  # pylint: disable=unused-import
+from chainsync.test_fixtures import db_session  # pylint: disable=unused-import, ungrouped-imports
 from ethpy.test_fixtures import local_chain, local_hyperdrive_chain  # pylint: disable=unused-import, ungrouped-imports
 
 # fixture arguments in test function have to be the same as the fixture name
@@ -50,8 +49,8 @@ def _to_unscaled_decimal(scaled_value: int) -> Decimal:
     return Decimal(str(FixedPoint(scaled_value=scaled_value)))
 
 
-def _decimal_almost_equal(a: Decimal, b: Decimal) -> bool:
-    return abs(a - b) < 1e-12
+def _decimal_almost_equal(a_val: Decimal, b_val: Decimal) -> bool:
+    return abs(a_val - b_val) < 1e-12
 
 
 class TestBotToDb:
@@ -65,8 +64,10 @@ class TestBotToDb:
         cycle_trade_policy: Type[BasePolicy],
         db_session: Session,
     ):
+        """Runs the entire pipeline and checks the database at the end.
+        All arguments are fixtures.
+        """
         # Get hyperdrive chain info
-        web3: Web3 = local_hyperdrive_chain["web3"]
         deploy_account: LocalAccount = local_hyperdrive_chain["deploy_account"]
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain["hyperdrive_contract_addresses"]
 

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -120,16 +120,6 @@ class TestBotToDb:
             exit_on_catch_up=True,
         )
 
-        # Run acquire data to get data from chain to db in subprocess
-        acquire_data(
-            start_block=8,  # First 7 blocks are deploying hyperdrive, ignore
-            eth_config=eth_config,
-            db_session=db_session,
-            contract_addresses=hyperdrive_contract_addresses,
-            # Exit the script after catching up to the chain
-            exit_on_catch_up=True,
-        )
-
         # Test db entries are what we expect
         # We don't coerce to float because we want exact values in decimal
         db_pool_config = get_pool_config(db_session, coerce_float=False)

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -7,7 +7,7 @@ from agent0.base.config import AgentConfig, EnvironmentConfig
 from agent0.base.policies import BasePolicy
 from agent0.hyperdrive.exec import run_agents
 from ethpy import EthConfig
-from ethpy.hyperdrive.addresses import HyperdriveAddresses
+from ethpy.hyperdrive import HyperdriveAddresses
 from fixedpointmath import FixedPoint
 from sqlalchemy.orm import Session
 

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -104,6 +104,7 @@ class TestBotToDb:
 
         # Run acquire data to get data from chain to db in subprocess
         acquire_data(
+            start_block=8,  # First 7 blocks are deploying hyperdrive, ignore
             eth_config=eth_config,
             db_session=db_session,
             contract_addresses=hyperdrive_contract_addresses,


### PR DESCRIPTION
This PR adds the first system test for elf-simulations.

Major changes:
- It's here! Adds a system test that runs from bots to postgres db on a local test chain.
- Adding custom bot for test fixtures that cycles through all trades with known amounts
- Moving `acquire_data.py` to be within chainsync package, and writing minimal entry point to call
   - Breaking change: data capture script renamed from `acquire_data.py` to `run_chainsync.py`
- Parameterizing `acquire_data.py` to allow for system tests
- Explicitly setting a precision and scale for the Numeric postgres type

Minor changes:
- Adding script for making vscode debugging pytest easier
- Moving helper function `get_web3_and_contracts` from agent0 to ethpy
- Adding `coerce_float` to all postgres getter functions
- Docstrings
- Formatting

Bug fixes:
- Fixed a bug that stores `invTimeStretch` as unscaled values
- Fixed a bug with postgres/python schema typing for `maturityTime`

TODO:
- Do more comparisons in system tests, e.g., how much base for closing longs, pool info, etc
- Break out system_test
- There are rounding issues with using in-memory sqlite, should use containerized postgres
   - https://github.com/delvtech/elf-simulations/issues/836