### PR TITLE
ignore top level .configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Environment variables
 *.env
 
+# user configs
+.configs
+
 # Python environments
 .venv
 env/


### PR DESCRIPTION
Personal space for keeping bot configs.  I could also see the .configs living in lib/agent0 along with it's own .gitignore