### PR TITLE
Update pyproject.toml to ignore the .venv directory when linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,21 +33,14 @@ max-line-length = "120"
 line-length = "120"
 extend-exclude = "\\.ipynb"
 
+[tool.pylint]
+exclude = ["agent_0", "hyperdrive_solidity", ".venv", ".vscode", "docs"]
+
 [tool.pylance]
-exclude = [
-    "agent_0",
-    "hyperdrive_solidity",
-]
+exclude = ["agent_0", "hyperdrive_solidity", ".venv", ".vscode", "docs"]
 
 [tool.pyright]
-exclude = [
-    "agent_0",
-    ".venv",
-    ".vscode",
-    "docs",
-    "hyperdrive_solidity/.venv",
-    "hyperdrive_solidity",
-]
+exclude = ["agent_0", "hyperdrive_solidity", ".venv", ".vscode", "docs"]
 
 [tool.ruff]
 # Default is: pycodestyle (E) and Pyflakes (F)


### PR DESCRIPTION
Helping VsCode ignore .venv by updating the pyproject.toml.  We need to make sure that pylint, pyright and pylance all exclude .venv and hyperdrive_solidity/.venv otherwise it gets bogged down with errors.