### PR TITLE
Using local postgres for pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Due to a lack of known precision, operations against Python floats are not allow
 However, operations against `int` are allowed.
 In this case, the `int` _argument_ is assumed to be "unscaled", i.e. if you write `int(8) * FixedPoint(8)` we will scale up the first variable return a `FixedPoint` number that represents the float `64.0` in 18-decimal FixedPoint format.
 So in this example the internal representation of that operation would be `64*10**18`.
-If you cast FixedPoint numbers to ints or floats you will get "unscaled" representation, e.g. `float(FixedPoint(8.0)) == 8.0` and `int(FixedPoint(8.528)) == 8`.
+If you cast FixedPoint numbers to ints or floats you will get "unscaled" representation, e.g. `float(FixedPoint("8.0")) == 8.0` and `int(FixedPoint("8.528")) == 8`.
 
-If you want the integer scaled representation, which can be useful for communicating with Solidity contracts, you must ask for it explicitly, e.g. `FixedPoint(8.52).scaled_value == 8520000000000000000`.
+If you want the integer scaled representation, which can be useful for communicating with Solidity contracts, you must ask for it explicitly, e.g. `FixedPoint("8.52").scaled_value == 8520000000000000000`.
 Conversely, if you want to initialize a FixedPoint variable using the scaled integer representation, then you need to instantiate the variable using the `scaled_value` argument, e.g. `FixedPoint(scaled_value=8)`.
 In that example, the internal representation is `8`, so casting it to a float would produce a small value: `float(FixedPoint(scaled_value=8)) == 8e-18`.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ In that example, the internal representation is `8`, so casting it to a float wo
 
 To understand more, we recommend that you study the fixed point tests and source implementation in `elfpy/math/`.
 
+Warning! Using floating point as a constructor to FixedPoint can cause loss of precision. For example, 
+```
+>>> FixedPoint(1e18)
+FixedPoint("1000000000000000042.420637374017961984")
+```
+Allowing floating point in the constructor of FixedPoint will be removed in a future version of `fixedpointmath`.
+
 ## Modifying configuration for agent deployment
 
 Follow `lib/agent0/README.md` for agent deployment.

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,12 @@ from ethpy.test_fixtures import local_chain, local_hyperdrive_chain
 # instead of allowing pytest to catch the exception and report
 # Based on https://stackoverflow.com/questions/62419998/how-can-i-get-pytest-to-not-catch-exceptions/62563106#62563106
 
+# IMPORTANT NOTE!!!!!
+# If you end up using this debugging method, this will catch exceptions before teardown of fixtures
+# This means that the local postgres fixture (which launches a docker container) will not automatically
+# be cleaned up if you, e.g., use the debugger and a db test fails. Make sure to manually clean up.
+# TODO maybe automatically close the container on catch here
+
 # Use this in conjunction with the following launch.json configuration:
 #      {
 #        "name": "Debug Current Test",

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@
 import os
 
 import pytest
+from agent0.test_fixtures import cycle_trade_policy
 from chainsync.test_fixtures import database_engine, db_session, dummy_session, psql_docker
 from ethpy.test_fixtures import local_chain, local_hyperdrive_chain
 
@@ -39,4 +40,12 @@ if os.getenv("_PYTEST_RAISE", "0") != "0":
 # Importing all fixtures here and defining here
 # This allows for users of fixtures to not have to import all dependency fixtures when running
 # TODO this means pytest can only be ran from this directory
-__all__ = ["database_engine", "db_session", "dummy_session", "psql_docker", "local_chain", "local_hyperdrive_chain"]
+__all__ = [
+    "database_engine",
+    "db_session",
+    "dummy_session",
+    "psql_docker",
+    "local_chain",
+    "local_hyperdrive_chain",
+    "cycle_trade_policy",
+]

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,13 @@
+# Ignore docstrings for this file
+# pylint: disable=missing-docstring
+
+
+import os
+
+import pytest
+from chainsync.test_fixtures import database_engine, db_session, dummy_session, psql_docker
+from ethpy.test_fixtures import local_chain, local_hyperdrive_chain
+
 # Hack to allow for vscode debugger to throw exception immediately
 # instead of allowing pytest to catch the exception and report
 # Based on https://stackoverflow.com/questions/62419998/how-can-i-get-pytest-to-not-catch-exceptions/62563106#62563106
@@ -15,15 +25,6 @@
 #            "_PYTEST_RAISE": "1"
 #        },
 #      },
-
-# Ignore docstrings for this file
-# pylint: disable=missing-docstring
-
-
-import os
-
-import pytest
-
 if os.getenv("_PYTEST_RAISE", "0") != "0":
 
     @pytest.hookimpl(tryfirst=True)
@@ -33,3 +34,9 @@ if os.getenv("_PYTEST_RAISE", "0") != "0":
     @pytest.hookimpl(tryfirst=True)
     def pytest_internalerror(excinfo):
         raise excinfo.value
+
+
+# Importing all fixtures here and defining here
+# This allows for users of fixtures to not have to import all dependency fixtures when running
+# TODO this means pytest can only be ran from this directory
+__all__ = ["database_engine", "db_session", "dummy_session", "psql_docker", "local_chain", "local_hyperdrive_chain"]

--- a/lib/agent0/agent0/base/config/agent_config.py
+++ b/lib/agent0/agent0/base/config/agent_config.py
@@ -39,7 +39,7 @@ class AgentConfig:
     name: str = "BoringBotty"
     base_budget_wei: Budget | int = Budget()
     eth_budget_wei: Budget | int = Budget(min_wei=0, max_wei=0)
-    slippage_tolerance: FixedPoint = FixedPoint(0.0001)  # default to 0.01%
+    slippage_tolerance: FixedPoint = FixedPoint("0.0001")  # default to 0.01%
     number_of_agents: int = 1
     private_keys: list[str] | None = None
     init_kwargs: dict = field(default_factory=dict)

--- a/lib/agent0/agent0/base/config/budget.py
+++ b/lib/agent0/agent0/base/config/budget.py
@@ -16,10 +16,10 @@ class Budget:
     Wei in the variables below refers to the smallest unit of base, not to ETH.
     """
 
-    mean_wei: int = int(5_000 * 1e18)
-    std_wei: int = int(2_000 * 1e18)
-    min_wei: int = int(1_000 * 1e18)
-    max_wei: int = int(10_000 * 1e18)
+    mean_wei: int = FixedPoint(5_000).scaled_value
+    std_wei: int = FixedPoint(2_000).scaled_value
+    min_wei: int = FixedPoint(1_000).scaled_value
+    max_wei: int = FixedPoint(10_000).scaled_value
 
     def sample_budget(self, rng: NumpyGenerator) -> FixedPoint:
         """Return a sample from a clipped normal distribution.

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -229,7 +229,7 @@ async def async_match_contract_call_to_trade(
 
     # TODO: The following variables are hard coded for now, but should be specified in the trade spec
     min_apr = int(1)
-    max_apr = int(1e18)
+    max_apr = FixedPoint(1).scaled_value
     as_underlying = True
     match trade.action_type:
         case HyperdriveActionType.INITIALIZE_MARKET:

--- a/lib/agent0/agent0/test_fixtures/cycle_trade_policy.py
+++ b/lib/agent0/agent0/test_fixtures/cycle_trade_policy.py
@@ -44,7 +44,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                     market_type=MarketType.HYPERDRIVE,
                     market_action=HyperdriveMarketAction(
                         action_type=HyperdriveActionType.ADD_LIQUIDITY,
-                        trade_amount=FixedPoint(scaled_value=int(11111e18)),
+                        trade_amount=FixedPoint(11111),
                         wallet=wallet,
                     ),
                 )
@@ -56,7 +56,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                     market_type=MarketType.HYPERDRIVE,
                     market_action=HyperdriveMarketAction(
                         action_type=HyperdriveActionType.OPEN_LONG,
-                        trade_amount=FixedPoint(scaled_value=int(22222e18)),
+                        trade_amount=FixedPoint(22222),
                         wallet=wallet,
                     ),
                 )
@@ -68,7 +68,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                     market_type=MarketType.HYPERDRIVE,
                     market_action=HyperdriveMarketAction(
                         action_type=HyperdriveActionType.OPEN_SHORT,
-                        trade_amount=FixedPoint(scaled_value=int(33333e18)),
+                        trade_amount=FixedPoint(33333),
                         wallet=wallet,
                     ),
                 )
@@ -138,7 +138,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
                     market_type=MarketType.HYPERDRIVE,
                     market_action=HyperdriveMarketAction(
                         action_type=HyperdriveActionType.OPEN_LONG,
-                        trade_amount=FixedPoint(scaled_value=int(1e18)),
+                        trade_amount=FixedPoint(1),
                         wallet=wallet,
                     ),
                 )

--- a/lib/agent0/bin/checkpoint_bot.py
+++ b/lib/agent0/bin/checkpoint_bot.py
@@ -20,6 +20,7 @@ from ethpy.base import (
     smart_contract_transact,
 )
 from ethpy.hyperdrive import fetch_hyperdrive_address_from_url, get_hyperdrive_config
+from fixedpointmath import FixedPoint
 from web3.contract.contract import Contract
 
 # The portion of the checkpoint that the bot will wait before attempting to
@@ -69,7 +70,7 @@ def main() -> None:
     )
 
     # Fund the checkpoint sender with some ETH.
-    balance = int(100e18)
+    balance = FixedPoint(100).scaled_value
     sender = EthAgent(Account().create("CHECKPOINT_BOT"))
     set_anvil_account_balance(web3, sender.address, balance)
     logging.info("Successfully funded the sender=%s.", sender.address)

--- a/lib/agent0/examples/example_agent.py
+++ b/lib/agent0/examples/example_agent.py
@@ -37,7 +37,7 @@ class CycleTradesPolicy(HyperdrivePolicy):
         rng: NumpyGenerator | None = None,
         slippage_tolerance: FixedPoint | None = None,
         # Add additional parameters for custom policy here
-        static_trade_amount_wei: int = int(100e18),  # 100 base
+        static_trade_amount_wei: int = FixedPoint(100).scaled_value,  # 100 base
     ):
         self.static_trade_amount_wei = static_trade_amount_wei
         # We want to do a sequence of trades one at a time, so we keep an internal counter based on
@@ -174,10 +174,10 @@ agent_config: list[AgentConfig] = [
     AgentConfig(
         policy=CycleTradesPolicy,
         number_of_agents=1,
-        slippage_tolerance=FixedPoint(0.0001),
-        base_budget_wei=int(10_000e18),  # 10k base
-        eth_budget_wei=int(10e18),  # 10 base
-        init_kwargs={"static_trade_amount_wei": int(100e18)},  # 100 base static trades
+        slippage_tolerance=FixedPoint("0.0001"),
+        base_budget_wei=FixedPoint(10_000).scaled_value,  # 10k base
+        eth_budget_wei=FixedPoint(10).scaled_value,  # 10 base
+        init_kwargs={"static_trade_amount_wei": FixedPoint(100).scaled_value)},  # 100 base static trades
     ),
 ]
 

--- a/lib/agent0/examples/example_agent.py
+++ b/lib/agent0/examples/example_agent.py
@@ -177,7 +177,7 @@ agent_config: list[AgentConfig] = [
         slippage_tolerance=FixedPoint("0.0001"),
         base_budget_wei=FixedPoint(10_000).scaled_value,  # 10k base
         eth_budget_wei=FixedPoint(10).scaled_value,  # 10 base
-        init_kwargs={"static_trade_amount_wei": FixedPoint(100).scaled_value)},  # 100 base static trades
+        init_kwargs={"static_trade_amount_wei": FixedPoint(100).scaled_value},  # 100 base static trades
     ),
 ]
 

--- a/lib/agent0/examples/hyperdrive_agents.py
+++ b/lib/agent0/examples/hyperdrive_agents.py
@@ -32,35 +32,35 @@ agent_config: list[AgentConfig] = [
     AgentConfig(
         policy=Policies.random_agent,
         number_of_agents=3,
-        slippage_tolerance=FixedPoint(0.0001),
+        slippage_tolerance=FixedPoint("0.0001"),
         base_budget_wei=Budget(
-            mean_wei=int(5_000e18),  # 5k base
-            std_wei=int(1_000e18),  # 1k base
+            mean_wei=FixedPoint(5_000).scaled_value,  # 5k base
+            std_wei=FixedPoint(1_000).scaled_value,  # 1k base
             min_wei=1,  # 1 WEI base
-            max_wei=int(100_000e18),  # 100k base
+            max_wei=FixedPoint(100_000).scaled_value,  # 100k base
         ),
-        eth_budget_wei=Budget(min_wei=int(1e18), max_wei=int(1e18)),
-        init_kwargs={"trade_chance": FixedPoint(0.8)},
+        eth_budget_wei=Budget(min_wei=FixedPoint(1).scaled_value, max_wei=FixedPoint(1).scaled_value),
+        init_kwargs={"trade_chance": FixedPoint("0.8")},
     ),
     AgentConfig(
         policy=Policies.long_louie,
         number_of_agents=0,
         # Fixed budgets
-        base_budget_wei=int(5_000e18),  # 5k base
-        eth_budget_wei=int(1e18),  # 1 base
-        init_kwargs={"trade_chance": FixedPoint(0.8), "risk_threshold": FixedPoint(0.9)},
+        base_budget_wei=FixedPoint(5_000).scaled_value,  # 5k base
+        eth_budget_wei=FixedPoint(1).scaled_value,  # 1 base
+        init_kwargs={"trade_chance": FixedPoint("0.8"), "risk_threshold": FixedPoint("0.9")},
     ),
     AgentConfig(
         policy=Policies.short_sally,
         number_of_agents=0,
         base_budget_wei=Budget(
-            mean_wei=int(5_000e18),  # 5k base
-            std_wei=int(1_000e18),  # 1k base
+            mean_wei=FixedPoint(5_000).scaled_value,  # 5k base
+            std_wei=FixedPoint(1_000).scaled_value,  # 1k base
             min_wei=1,  # 1 WEI base
-            max_wei=int(100_000e18),  # 100k base
+            max_wei=FixedPoint(100_000).scaled_value,  # 100k base
         ),
-        eth_budget_wei=Budget(min_wei=int(1e18), max_wei=int(1e18)),
-        init_kwargs={"trade_chance": FixedPoint(0.8), "risk_threshold": FixedPoint(0.8)},
+        eth_budget_wei=Budget(min_wei=FixedPoint(1).scaled_value, max_wei=FixedPoint(1).scaled_value),
+        init_kwargs={"trade_chance": FixedPoint("0.8"), "risk_threshold": FixedPoint("0.8")},
     ),
 ]
 

--- a/lib/chainsync/chainsync/db/base/interface.py
+++ b/lib/chainsync/chainsync/db/base/interface.py
@@ -8,7 +8,7 @@ from typing import Type, cast
 
 import pandas as pd
 import sqlalchemy
-from chainsync import build_postgres_config
+from chainsync import PostgresConfig, build_postgres_config
 from sqlalchemy import URL, Column, Engine, MetaData, String, Table, create_engine, exc, func, inspect
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.declarative import declared_attr
@@ -56,7 +56,7 @@ def drop_table(session: Session, table_name: str) -> None:
     table.drop(checkfirst=True, bind=bind)
 
 
-def initialize_engine() -> Engine:
+def initialize_engine(postgres_config: PostgresConfig | None = None) -> Engine:
     """Initializes the postgres engine from config
 
     Returns
@@ -64,7 +64,8 @@ def initialize_engine() -> Engine:
     Engine
         The initialized engine object connected to postgres
     """
-    postgres_config = build_postgres_config()
+    if postgres_config is None:
+        postgres_config = build_postgres_config()
 
     url_object = URL.create(
         drivername="postgresql",

--- a/lib/chainsync/chainsync/db/base/schema_test.py
+++ b/lib/chainsync/chainsync/db/base/schema_test.py
@@ -13,9 +13,6 @@ class TestUserMapTable:
 
     def test_create_user_map(self, db_session):
         """Create and entry"""
-        # Note: this test is using in-memory sqlite, which doesn't seem to support
-        # autoincrement ids without init, whereas postgres does this with no issues
-        # Hence, we explicitly add id here
         user_map = UserMap(address="1", username="a")
         db_session.add(user_map)
         db_session.commit()

--- a/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
@@ -151,10 +151,6 @@ class TestPoolConfigInterface:
 
         pool_config_df_1 = get_pool_config(db_session)
         assert len(pool_config_df_1) == 1
-        # TODO In testing, we use sqlite, which does not implement the fixed point Numeric type
-        # Internally, they store Numeric types as floats, hence we see rounding errors in testing
-        # This does not happen in postgres, where these values match exactly.
-        # https://github.com/delvtech/elf-simulations/issues/836
         np.testing.assert_array_equal(pool_config_df_1["initialSharePrice"], np.array([3.2]))
 
         pool_config_2 = PoolConfig(contractAddress="1", initialSharePrice=Decimal("3.4"))
@@ -185,9 +181,7 @@ class TestPoolConfigInterface:
         assert pool_config_df_1.loc[0, "initialSharePrice"] == 3.2
 
         # Nothing should happen if we give the same pool_config
-        # TODO Below is a hack due to sqlite not having numerics
-        # We explicitly print 18 spots after floating point to match rounding error in sqlite
-        pool_config_2 = PoolConfig(contractAddress="0", initialSharePrice=Decimal(f"{3.2:.18f}"))
+        pool_config_2 = PoolConfig(contractAddress="0", initialSharePrice=Decimal("3.2"))
         add_pool_config(pool_config_2, db_session)
         pool_config_df_2 = get_pool_config(db_session)
         assert len(pool_config_df_2) == 1

--- a/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
@@ -6,9 +6,6 @@ import numpy as np
 import pytest
 from chainsync.db.base import get_latest_block_number_from_table
 
-# Ignoring unused import warning, fixtures are used through variable name
-from chainsync.test_fixtures import db_session  # pylint: disable=unused-import
-
 from .interface import (
     add_checkpoint_infos,
     add_pool_config,
@@ -29,10 +26,8 @@ from .interface import (
 )
 from .schema import CheckpointInfo, HyperdriveTransaction, PoolConfig, PoolInfo, WalletDelta, WalletInfo
 
-# fixture arguments in test function have to be the same as the fixture name
-# pylint: disable=redefined-outer-name
 
-
+# These tests are using fixtures defined in conftest.py
 class TestTransactionInterface:
     """Testing postgres interface for transaction table"""
 

--- a/lib/chainsync/chainsync/db/hyperdrive/schema.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema.py
@@ -85,11 +85,7 @@ class WalletInfo(Base):
     __tablename__ = "walletinfo"
 
     # Default table primary key
-    # Note that we use postgres in production and sqlite in testing, but sqlite has issues with
-    # autoincrement with BigIntegers. Hence, we use the Integer variant when using sqlite in tests
-    id: Mapped[int] = mapped_column(
-        BigInteger().with_variant(Integer, "sqlite"), primary_key=True, init=False, autoincrement=True
-    )
+    id: Mapped[int] = mapped_column(BigInteger(), primary_key=True, init=False, autoincrement=True)
 
     blockNumber: Mapped[int] = mapped_column(BigInteger, index=True)
     walletAddress: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
@@ -111,11 +107,7 @@ class WalletDelta(Base):
     __tablename__ = "walletdelta"
 
     # Default table primary key
-    # Note that we use postgres in production and sqlite in testing, but sqlite has issues with
-    # autoincrement with BigIntegers. Hence, we use the Integer variant when using sqlite in tests
-    id: Mapped[int] = mapped_column(
-        BigInteger().with_variant(Integer, "sqlite"), primary_key=True, init=False, autoincrement=True
-    )
+    id: Mapped[int] = mapped_column(BigInteger(), primary_key=True, init=False, autoincrement=True)
     transactionHash: Mapped[str] = mapped_column(String, index=True)
     blockNumber: Mapped[int] = mapped_column(BigInteger, index=True)
     walletAddress: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
@@ -138,11 +130,7 @@ class HyperdriveTransaction(Base):
     __tablename__ = "transactions"
 
     # Default table primary key
-    # Note that we use postgres in production and sqlite in testing, but sqlite has issues with
-    # autoincrement with BigIntegers. Hence, we use the Integer variant when using sqlite in tests
-    id: Mapped[int] = mapped_column(
-        BigInteger().with_variant(Integer, "sqlite"), primary_key=True, init=False, autoincrement=True
-    )
+    id: Mapped[int] = mapped_column(BigInteger(), primary_key=True, init=False, autoincrement=True)
     transactionHash: Mapped[str] = mapped_column(String, index=True, unique=True)
 
     #### Fields from base transactions ####

--- a/lib/chainsync/chainsync/db/hyperdrive/schema.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import Union
 
 from chainsync.db.base import Base
-from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Integer, Numeric, String
+from sqlalchemy import BigInteger, Boolean, DateTime, Integer, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 # pylint: disable=invalid-name
@@ -91,7 +91,7 @@ class WalletInfo(Base):
         BigInteger().with_variant(Integer, "sqlite"), primary_key=True, init=False, autoincrement=True
     )
 
-    blockNumber: Mapped[int] = mapped_column(BigInteger, ForeignKey("poolinfo.blockNumber"), index=True)
+    blockNumber: Mapped[int] = mapped_column(BigInteger, index=True)
     walletAddress: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
     # baseTokenType can be BASE, LONG, SHORT, LP, or WITHDRAWAL_SHARE
     baseTokenType: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
@@ -116,8 +116,8 @@ class WalletDelta(Base):
     id: Mapped[int] = mapped_column(
         BigInteger().with_variant(Integer, "sqlite"), primary_key=True, init=False, autoincrement=True
     )
-    transactionHash: Mapped[str] = mapped_column(String, ForeignKey("transactions.transactionHash"), index=True)
-    blockNumber: Mapped[int] = mapped_column(BigInteger, ForeignKey("poolinfo.blockNumber"), index=True)
+    transactionHash: Mapped[str] = mapped_column(String, index=True)
+    blockNumber: Mapped[int] = mapped_column(BigInteger, index=True)
     walletAddress: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
     # baseTokenType can be BASE, LONG, SHORT, LP, or WITHDRAWAL_SHARE
     baseTokenType: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
@@ -146,7 +146,7 @@ class HyperdriveTransaction(Base):
     transactionHash: Mapped[str] = mapped_column(String, index=True, unique=True)
 
     #### Fields from base transactions ####
-    blockNumber: Mapped[int] = mapped_column(BigInteger, ForeignKey("poolinfo.blockNumber"), index=True)
+    blockNumber: Mapped[int] = mapped_column(BigInteger, index=True)
     transactionIndex: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
     nonce: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
     # Transaction receipt to/from

--- a/lib/chainsync/chainsync/db/hyperdrive/schema.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema.py
@@ -35,7 +35,7 @@ class PoolConfig(Base):
     curveFee: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     flatFee: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     governanceFee: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
-    oracleSize: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    oracleSize: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
     updateGap: Mapped[Union[int, None]] = mapped_column(Integer, default=None)
     invTimeStretch: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     updateGap: Mapped[Union[int, None]] = mapped_column(Integer, default=None)

--- a/lib/chainsync/chainsync/db/hyperdrive/schema_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema_test.py
@@ -16,9 +16,6 @@ class TestTransactionTable:
 
     def test_create_transaction(self, db_session):
         """Create and entry"""
-        # Note: this test is using in-memory sqlite, which doesn't seem to support
-        # autoincrement ids without init, whereas postgres does this with no issues
-        # Hence, we explicitly add id here
         transaction = HyperdriveTransaction(blockNumber=1, transactionHash="a", event_value=Decimal("3.2"))
         db_session.add(transaction)
         db_session.commit()
@@ -59,9 +56,6 @@ class TestCheckpointTable:
 
     def test_create_checkpoint(self, db_session):
         """Create and entry"""
-        # Note: this test is using in-memory sqlite, which doesn't seem to support
-        # autoincrement ids without init, whereas postgres does this with no issues
-        # Hence, we explicitly add id here
         timestamp = datetime.now()
         checkpoint = CheckpointInfo(blockNumber=1, timestamp=timestamp)
         db_session.add(checkpoint)
@@ -172,9 +166,6 @@ class TestWalletDeltaTable:
 
     def test_create_wallet_delta(self, db_session):
         """Create and entry"""
-        # Note: this test is using in-memory sqlite, which doesn't seem to support
-        # autoincrement ids without init, whereas postgres does this with no issues
-        # Hence, we explicitly add id here
         wallet_delta = WalletDelta(blockNumber=1, transactionHash="a", delta=Decimal("3.2"))
         db_session.add(wallet_delta)
         db_session.commit()
@@ -211,9 +202,6 @@ class TestWalletInfoTable:
 
     def test_create_wallet_info(self, db_session):
         """Create and entry"""
-        # Note: this test is using in-memory sqlite, which doesn't seem to support
-        # autoincrement ids without init, whereas postgres does this with no issues
-        # Hence, we explicitly add id here
         wallet_info = WalletInfo(blockNumber=1, tokenValue=Decimal("3.2"))
         db_session.add(wallet_info)
         db_session.commit()

--- a/lib/chainsync/chainsync/db/hyperdrive/schema_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema_test.py
@@ -2,13 +2,9 @@
 from datetime import datetime
 from decimal import Decimal
 
-# Ignoring unused import warning, fixtures are used through variable name
-from chainsync.test_fixtures import db_session  # pylint: disable=unused-import
-
 from .schema import CheckpointInfo, HyperdriveTransaction, PoolConfig, PoolInfo, WalletDelta, WalletInfo
 
-# fixture arguments in test function have to be the same as the fixture name
-# pylint: disable=redefined-outer-name
+# These tests are using fixtures defined in conftest.py
 
 
 class TestTransactionTable:

--- a/lib/chainsync/chainsync/test_fixtures/__init__.py
+++ b/lib/chainsync/chainsync/test_fixtures/__init__.py
@@ -1,3 +1,3 @@
 """Test fixtures for chainsync"""
-from .db_session import db_session
+from .db_session import database_engine, db_session, psql_docker
 from .dummy_session import dummy_session

--- a/lib/chainsync/chainsync/test_fixtures/db_session.py
+++ b/lib/chainsync/chainsync/test_fixtures/db_session.py
@@ -30,10 +30,10 @@ def psql_docker() -> Generator[PostgresConfig, Any, Any]:
     container = client.containers.run(
         image="postgres:12",
         auto_remove=True,
-        environment=dict(
-            POSTGRES_USER=postgres_config.POSTGRES_USER,
-            POSTGRES_PASSWORD=postgres_config.POSTGRES_PASSWORD,
-        ),
+        environment={
+            "POSTGRES_USER": postgres_config.POSTGRES_USER,
+            "POSTGRES_PASSWORD": postgres_config.POSTGRES_PASSWORD,
+        },
         name="test_postgres",
         ports={"5432/tcp": ("127.0.0.1", postgres_config.POSTGRES_PORT)},
         detach=True,

--- a/lib/chainsync/chainsync/test_fixtures/db_session.py
+++ b/lib/chainsync/chainsync/test_fixtures/db_session.py
@@ -41,7 +41,8 @@ def psql_docker() -> Generator[PostgresConfig, Any, Any]:
 
     yield postgres_config
 
-    container.stop()
+    # Docker doesn't play nice with types
+    container.stop()  # type:ignore
 
 
 @pytest.fixture(scope="session")

--- a/lib/chainsync/chainsync/test_fixtures/db_session.py
+++ b/lib/chainsync/chainsync/test_fixtures/db_session.py
@@ -1,20 +1,73 @@
 """Pytest fixture that creates an in memory db session and creates the base db schema"""
+import time
 from typing import Any, Generator
 
+import docker
 import pytest
-from chainsync.db.base import Base
-from sqlalchemy import create_engine
+from chainsync import PostgresConfig
+from chainsync.db.base import Base, initialize_engine
+from pytest_postgresql.janitor import DatabaseJanitor
 from sqlalchemy.orm import Session, sessionmaker
 
 
-@pytest.fixture(scope="function")
-def db_session() -> Generator[Session, Any, Any]:
-    """Initializes the in memory db session and creates the db schema"""
-    engine = create_engine("sqlite:///:memory:")  # in-memory SQLite database for testing
-    session = sessionmaker(bind=engine)
+@pytest.fixture(scope="session")
+def psql_docker() -> Generator[PostgresConfig, Any, Any]:
+    client = docker.from_env()
 
-    Base.metadata.create_all(engine)  # create tables
+    # Using these config for tests
+    postgres_config = PostgresConfig(
+        POSTGRES_USER="admin",
+        POSTGRES_PASSWORD="password",
+        POSTGRES_DB="postgres_db_test",
+        POSTGRES_HOST="localhost",
+        POSTGRES_PORT=5555,
+    )
+
+    container = client.containers.run(
+        image="postgres:12",
+        auto_remove=True,
+        environment=dict(
+            POSTGRES_USER=postgres_config.POSTGRES_USER,
+            POSTGRES_PASSWORD=postgres_config.POSTGRES_PASSWORD,
+        ),
+        name="test_postgres",
+        ports={"5432/tcp": ("127.0.0.1", postgres_config.POSTGRES_PORT)},
+        detach=True,
+        remove=True,
+    )
+
+    # Wait for the container to start
+    time.sleep(5)
+
+    yield postgres_config
+
+    container.stop()
+
+
+@pytest.fixture(scope="session")
+def database_engine(psql_docker):
+    # Using default postgres info
+    # Renaming variable to match what it actually is, i.e., the postgres config
+    postgres_config = psql_docker
+    with DatabaseJanitor(
+        user=postgres_config.POSTGRES_USER,
+        host="localhost",
+        port=postgres_config.POSTGRES_PORT,
+        dbname=postgres_config.POSTGRES_DB,
+        version=12,
+        password=postgres_config.POSTGRES_PASSWORD,
+    ):
+        engine = initialize_engine(postgres_config)
+        yield engine
+
+
+@pytest.fixture(scope="function")
+def db_session(database_engine) -> Generator[Session, Any, Any]:
+    """Initializes the in memory db session and creates the db schema"""
+    session = sessionmaker(bind=database_engine)
+
+    Base.metadata.create_all(database_engine)  # create tables
     db_session_ = session()
     yield db_session_
     db_session_.close()
-    Base.metadata.drop_all(engine)  # drop tables
+    Base.metadata.drop_all(database_engine)  # drop tables

--- a/lib/chainsync/chainsync/test_fixtures/db_session.py
+++ b/lib/chainsync/chainsync/test_fixtures/db_session.py
@@ -9,9 +9,13 @@ from chainsync.db.base import Base, initialize_engine
 from pytest_postgresql.janitor import DatabaseJanitor
 from sqlalchemy.orm import Session, sessionmaker
 
+# fixture arguments in test function have to be the same as the fixture name
+# pylint: disable=redefined-outer-name
+
 
 @pytest.fixture(scope="session")
 def psql_docker() -> Generator[PostgresConfig, Any, Any]:
+    """Test fixture for running postgres in docker"""
     client = docker.from_env()
 
     # Using these config for tests
@@ -47,6 +51,7 @@ def psql_docker() -> Generator[PostgresConfig, Any, Any]:
 
 @pytest.fixture(scope="session")
 def database_engine(psql_docker):
+    """Test fixture creating psql engine on local postgres container"""
     # Using default postgres info
     # Renaming variable to match what it actually is, i.e., the postgres config
     postgres_config = psql_docker

--- a/lib/chainsync/chainsync/test_fixtures/db_session.py
+++ b/lib/chainsync/chainsync/test_fixtures/db_session.py
@@ -1,6 +1,6 @@
 """Pytest fixture that creates an in memory db session and creates the base db schema"""
 import time
-from typing import Any, Iterator
+from typing import Iterator
 
 import docker
 import pytest

--- a/lib/chainsync/chainsync/test_fixtures/db_session.py
+++ b/lib/chainsync/chainsync/test_fixtures/db_session.py
@@ -1,6 +1,6 @@
 """Pytest fixture that creates an in memory db session and creates the base db schema"""
 import time
-from typing import Any, Generator
+from typing import Any, Iterator
 
 import docker
 import pytest
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 
 @pytest.fixture(scope="session")
-def psql_docker() -> Generator[PostgresConfig, Any, Any]:
+def psql_docker() -> Iterator[PostgresConfig]:
     """Test fixture for running postgres in docker"""
     client = docker.from_env()
 
@@ -68,7 +68,7 @@ def database_engine(psql_docker):
 
 
 @pytest.fixture(scope="function")
-def db_session(database_engine) -> Generator[Session, Any, Any]:
+def db_session(database_engine) -> Iterator[Session]:
     """Initializes the in memory db session and creates the db schema"""
     session = sessionmaker(bind=database_engine)
 

--- a/lib/chainsync/chainsync/test_fixtures/dummy_session.py
+++ b/lib/chainsync/chainsync/test_fixtures/dummy_session.py
@@ -1,5 +1,5 @@
 """Pytest fixture that creates an in memory db session and creates dummy db schemas"""
-from typing import Any, Iterator
+from typing import Iterator
 
 import pytest
 from sqlalchemy import String, create_engine

--- a/lib/chainsync/chainsync/test_fixtures/dummy_session.py
+++ b/lib/chainsync/chainsync/test_fixtures/dummy_session.py
@@ -1,5 +1,5 @@
 """Pytest fixture that creates an in memory db session and creates dummy db schemas"""
-from typing import Any, Generator
+from typing import Any, Iterator
 
 import pytest
 from sqlalchemy import String, create_engine
@@ -27,7 +27,7 @@ class DropMe(DummyBase):
 
 
 @pytest.fixture(scope="function")
-def dummy_session() -> Generator[Session, Any, Any]:
+def dummy_session() -> Iterator[Session]:
     """Dummy session fixture for tests"""
     engine = create_engine("sqlite:///:memory:")  # in-memory SQLite database for testing
     session = sessionmaker(bind=engine)

--- a/lib/ethpy/ethpy/hyperdrive/interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface.py
@@ -124,7 +124,7 @@ def get_hyperdrive_config(hyperdrive_contract: Contract) -> dict[str, Any]:
     pool_config["curveFee"] = FixedPoint(scaled_value=curve_fee)
     pool_config["flatFee"] = FixedPoint(scaled_value=flat_fee)
     pool_config["governanceFee"] = FixedPoint(scaled_value=governance_fee)
-    pool_config["oracleSize"] = FixedPoint(scaled_value=hyperdrive_config["oracleSize"])
+    pool_config["oracleSize"] = hyperdrive_config["oracleSize"]
     pool_config["updateGap"] = hyperdrive_config["updateGap"]
     return pool_config
 

--- a/lib/ethpy/ethpy/hyperdrive/interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface.py
@@ -159,7 +159,7 @@ def get_hyperdrive_market(web3: Web3, hyperdrive_contract: Contract) -> Hyperdri
         total_supply_longs={FixedPoint(0): FixedPoint(pool_info["longsOutstanding"])},
         total_supply_shorts={FixedPoint(0): FixedPoint(pool_info["shortsOutstanding"])},
         total_supply_withdraw_shares=FixedPoint(pool_info["totalSupplyWithdrawalShares"]),
-        variable_apr=FixedPoint(0.01),  # TODO: insert real value
+        variable_apr=FixedPoint("0.01"),  # TODO: insert real value
         withdraw_shares_ready_to_withdraw=FixedPoint(pool_info["withdrawalSharesReadyToWithdraw"]),
         withdraw_capital=FixedPoint(0),
         withdraw_interest=FixedPoint(0),

--- a/lib/ethpy/ethpy/test_fixtures/deploy_hyperdrive.py
+++ b/lib/ethpy/ethpy/test_fixtures/deploy_hyperdrive.py
@@ -34,10 +34,8 @@ def _calculateTimeStretch(apr: int) -> int:  # pylint: disable=invalid-name
         The scaled output time stretch
     """
     fp_apr = FixedPoint(scaled_value=apr)
-    time_stretch = FixedPoint(scaled_value=int(5.24592e18)) / (
-        FixedPoint(scaled_value=int(0.04665e18)) * (fp_apr * 100)
-    )
-    return (FixedPoint(scaled_value=int(1e18)) / time_stretch).scaled_value
+    time_stretch = FixedPoint("5.24592") / (FixedPoint("0.04665") * (fp_apr * 100))
+    return (FixedPoint(1) / time_stretch).scaled_value
 
 
 def initialize_deploy_account(web3: Web3) -> LocalAccount:
@@ -81,13 +79,13 @@ def deploy_hyperdrive_factory(rpc_url: str, deploy_account: LocalAccount) -> tup
     # TODO parameterize these parameters
     # pylint: disable=too-many-locals
     # Initial factory settings
-    initial_variable_rate = int(0.05e18)
-    curve_fee = int(0.1e18)  # 10%
-    flat_fee = int(0.0005e18)  # 0.05%
-    governance_fee = int(0.15e18)  # 15%
-    max_curve_fee = int(0.3e18)  # 30%
-    max_flat_fee = int(0.0015e18)  # 0.15%
-    max_governance_fee = int(0.30e18)  # 30%
+    initial_variable_rate = FixedPoint("0.05").scaled_value
+    curve_fee = FixedPoint("0.1").scaled_value  # 10%
+    flat_fee = FixedPoint("0.0005").scaled_value  # 0.05%
+    governance_fee = FixedPoint("0.15").scaled_value  # 15%
+    max_curve_fee = FixedPoint("0.3").scaled_value  # 30%
+    max_flat_fee = FixedPoint("0.0015").scaled_value  # 0.15%
+    max_governance_fee = FixedPoint("0.30").scaled_value  # 30%
     # Configuration settings
     abi_folder = "packages/hyperdrive/src/abis/"
 
@@ -182,15 +180,15 @@ def deploy_and_initialize_hyperdrive(
     # TODO parameterize these parameters
     # pylint: disable=too-many-locals
     # Initial hyperdrive settings
-    initial_contribution = int(100_000_000e18)
-    initial_share_price = int(1e18)
-    minimum_share_reserves = int(10e18)
+    initial_contribution = FixedPoint(100_000_000).scaled_value
+    initial_share_price = FixedPoint(1).scaled_value
+    minimum_share_reserves = FixedPoint(10).scaled_value
     position_duration = 604800  # 1 week
     checkpoint_duration = 3600  # 1 hour
-    time_stretch = _calculateTimeStretch(int(0.05e18))
+    time_stretch = _calculateTimeStretch(FixedPoint("0.05").scaled_value)
     oracle_size = 10
     update_gap = 3600  # 1 hour
-    initial_fixed_rate = int(0.05e18)
+    initial_fixed_rate = FixedPoint("0.05").scaled_value
 
     deploy_account_addr = Web3.to_checksum_address(deploy_account.address)
 

--- a/lib/ethpy/ethpy/test_fixtures/local_chain.py
+++ b/lib/ethpy/ethpy/test_fixtures/local_chain.py
@@ -1,7 +1,7 @@
 """Test fixture for deploying local anvil chain and initializing hyperdrive"""
 import subprocess
 import time
-from typing import Any, Generator
+from typing import Any, Iterator
 
 import pytest
 from ethpy.base import initialize_web3_with_http_provider
@@ -15,12 +15,12 @@ from .deploy_hyperdrive import deploy_and_initialize_hyperdrive, deploy_hyperdri
 
 
 @pytest.fixture(scope="function")
-def local_chain() -> Generator[str, Any, Any]:
+def local_chain() -> Iterator[str]:
     """Launches a local anvil chain for testing. Kills the anvil chain after.
 
     Returns
     -------
-    Generator[str, Any, Any]
+    Iterator[str]
         Yields the local anvil chain url
     """
     anvil_port = 9999

--- a/lib/ethpy/ethpy/test_fixtures/local_chain.py
+++ b/lib/ethpy/ethpy/test_fixtures/local_chain.py
@@ -1,7 +1,7 @@
 """Test fixture for deploying local anvil chain and initializing hyperdrive"""
 import subprocess
 import time
-from typing import Any, Iterator
+from typing import Iterator
 
 import pytest
 from ethpy.base import initialize_web3_with_http_provider

--- a/lib/ethpy/ethpy/test_fixtures/local_chain.py
+++ b/lib/ethpy/ethpy/test_fixtures/local_chain.py
@@ -74,6 +74,7 @@ def local_hyperdrive_chain(local_chain: str) -> dict:
     hyperdrive_addr = deploy_and_initialize_hyperdrive(web3, base_token_contract, factory_contract, account)
 
     return {
+        "rpc_url": local_chain,
         "web3": web3,
         "deploy_account": account,
         "hyperdrive_contract_addresses": HyperdriveAddresses(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,3 +20,6 @@ sphinxcontrib-napoleon>=0.7
 tomli>=2.0.1
 # urllib3 v2 requires OpenSSL v1.1.1+, but Vercel uses v1.0.2
 urllib3<2.0
+# Used for tests of db interface
+docker
+pytest-postgresql

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -138,7 +138,7 @@ class TestBotToDb:
             "curveFee": _to_unscaled_decimal(FixedPoint("0.1")),  # 10%
             "flatFee": _to_unscaled_decimal(FixedPoint("0.0005")),  # 0.05%
             "governanceFee": _to_unscaled_decimal(FixedPoint("0.15")),  # 15%
-            "oracleSize": _to_unscaled_decimal(FixedPoint("10")),
+            "oracleSize": 10,
             "updateGap": 3600,  # TODO don't know where this is getting set
             "invTimeStretch": expected_inv_timestretch,
         }

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -28,7 +28,7 @@ from agent0.test_fixtures import (  # pylint: disable=unused-import, ungrouped-i
     cycle_trade_policy,
 )
 from chainsync.test_fixtures import db_session  # pylint: disable=unused-import, ungrouped-imports
-from ethpy.test_fixtures import local_chain, local_hyperdrive_chain  # pylint: disable=unused-import, ungrouped-imports
+from ethpy.test_fixtures import local_hyperdrive_chain  # pylint: disable=unused-import, ungrouped-imports
 
 # fixture arguments in test function have to be the same as the fixture name
 # pylint: disable=redefined-outer-name
@@ -37,11 +37,9 @@ from ethpy.test_fixtures import local_chain, local_hyperdrive_chain  # pylint: d
 class TestLocalChain:
     """Tests bringing up local chain"""
 
-    # This is using 2 fixtures. Since hyperdrive_contract_address depends on local_chain, we need both here
-    # This is due to adding test fixtures through imports
-    def test_hyperdrive_init_and_deploy(self, local_chain: str, local_hyperdrive_chain: dict):
+    def test_hyperdrive_init_and_deploy(self, local_hyperdrive_chain: dict):
         """Create and entry"""
-        print(local_chain)
+        print(local_hyperdrive_chain["rpc_url"])
         print(local_hyperdrive_chain)
 
 
@@ -60,7 +58,6 @@ class TestBotToDb:
     # pylint: disable=too-many-locals, too-many-statements
     def test_bot_to_db(
         self,
-        local_chain: str,
         local_hyperdrive_chain: dict,
         cycle_trade_policy: Type[BasePolicy],
         db_session: Session,
@@ -69,6 +66,7 @@ class TestBotToDb:
         All arguments are fixtures.
         """
         # Get hyperdrive chain info
+        rpc_url: str = local_hyperdrive_chain["rpc_url"]
         deploy_account: LocalAccount = local_hyperdrive_chain["deploy_account"]
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain["hyperdrive_contract_addresses"]
 
@@ -102,7 +100,7 @@ class TestBotToDb:
         eth_config = EthConfig(
             # Artifacts_url isn't used here, as we explicitly set addresses and passed to run_bots
             ARTIFACTS_URL="not_used",
-            RPC_URL=local_chain,
+            RPC_URL=rpc_url,
             # Using default abi dir
         )
 

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -9,6 +9,7 @@ from agent0 import build_account_key_config_from_agent_config
 from agent0.base.config import AgentConfig, EnvironmentConfig
 from agent0.base.policies import BasePolicy
 from agent0.hyperdrive.exec import run_agents
+from agent0.test_fixtures import AgentDoneException
 from chainsync.db.hyperdrive.interface import get_pool_config, get_pool_info, get_transactions, get_wallet_deltas
 from chainsync.exec import acquire_data
 from eth_account.signers.local import LocalAccount
@@ -18,20 +19,7 @@ from ethpy.test_fixtures.deploy_hyperdrive import _calculateTimeStretch
 from fixedpointmath import FixedPoint
 from sqlalchemy.orm import Session
 
-# This pass is to prevent auto reordering imports from reordering the imports below
-pass  # pylint: disable=unnecessary-pass
-
-# Test fixture imports
-# Ignoring unused import warning, fixtures are used through variable name
-from agent0.test_fixtures import (  # pylint: disable=unused-import, ungrouped-imports
-    AgentDoneException,
-    cycle_trade_policy,
-)
-from chainsync.test_fixtures import db_session  # pylint: disable=unused-import, ungrouped-imports
-from ethpy.test_fixtures import local_hyperdrive_chain  # pylint: disable=unused-import, ungrouped-imports
-
-# fixture arguments in test function have to be the same as the fixture name
-# pylint: disable=redefined-outer-name
+# These tests are using fixtures defined in conftest.py
 
 
 class TestLocalChain:

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -31,8 +31,8 @@ class TestLocalChain:
         print(local_hyperdrive_chain)
 
 
-def _to_unscaled_decimal(scaled_value: int) -> Decimal:
-    return Decimal(str(FixedPoint(scaled_value=scaled_value)))
+def _to_unscaled_decimal(fp_val: FixedPoint) -> Decimal:
+    return Decimal(str(fp_val))
 
 
 class TestBotToDb:
@@ -121,24 +121,24 @@ class TestBotToDb:
         # Eventually, we want to parameterize these values to pass into deploying hyperdrive
         expected_timestretch_fp = FixedPoint(scaled_value=_calculateTimeStretch(FixedPoint("0.05").scaled_value))
         # TODO this is actually inv of solidity time stretch, fix
-        expected_timestretch = _to_unscaled_decimal((1 / expected_timestretch_fp).scaled_value)
-        expected_inv_timestretch = _to_unscaled_decimal(expected_timestretch_fp.scaled_value)
+        expected_timestretch = _to_unscaled_decimal((1 / expected_timestretch_fp))
+        expected_inv_timestretch = _to_unscaled_decimal(expected_timestretch_fp)
 
         expected_pool_config = {
             "contractAddress": hyperdrive_contract_addresses.mock_hyperdrive,
             "baseToken": hyperdrive_contract_addresses.base_token,
-            "initialSharePrice": _to_unscaled_decimal(FixedPoint("1").scaled_value),
-            "minimumShareReserves": _to_unscaled_decimal(FixedPoint("10").scaled_value),
+            "initialSharePrice": _to_unscaled_decimal(FixedPoint("1")),
+            "minimumShareReserves": _to_unscaled_decimal(FixedPoint("10")),
             "positionDuration": 604800,  # 1 week
             "checkpointDuration": 3600,  # 1 hour
             # TODO this is actually inv of solidity time stretch, fix
             "timeStretch": expected_timestretch,
             "governance": deploy_account.address,
             "feeCollector": deploy_account.address,
-            "curveFee": _to_unscaled_decimal(FixedPoint("0.1").scaled_value),  # 10%
-            "flatFee": _to_unscaled_decimal(FixedPoint("0.0005").scaled_value),  # 0.05%
-            "governanceFee": _to_unscaled_decimal(FixedPoint("0.15").scaled_value),  # 15%
-            "oracleSize": _to_unscaled_decimal(10),
+            "curveFee": _to_unscaled_decimal(FixedPoint("0.1")),  # 10%
+            "flatFee": _to_unscaled_decimal(FixedPoint("0.0005")),  # 0.05%
+            "governanceFee": _to_unscaled_decimal(FixedPoint("0.15")),  # 15%
+            "oracleSize": _to_unscaled_decimal(FixedPoint("10")),
             "updateGap": 3600,  # TODO don't know where this is getting set
             "invTimeStretch": expected_inv_timestretch,
         }


### PR DESCRIPTION
1. Spinning local postgres container for testing (https://github.com/delvtech/elf-simulations/issues/836)
2. Using conftest for test fixtures to avoid importing fixture dependencies in tests
3. Fixing rounding bugs with fixedpoint (https://github.com/delvtech/agent_0/issues/21)