### PR TITLE
Fixing postgres fixture

### DIFF
--- a/lib/chainsync/chainsync/analysis/data_to_analysis.py
+++ b/lib/chainsync/chainsync/analysis/data_to_analysis.py
@@ -31,7 +31,18 @@ pd.set_option("display.max_columns", None)
 def _df_to_db(insert_df: pd.DataFrame, schema_obj: Type[Base], session: Session):
     """Helper function to add a dataframe to a database"""
     table_name = schema_obj.__tablename__
-    insert_df.to_sql(table_name, con=session.connection(), if_exists="append", method="multi", index=False)
+
+    # dataframe to_sql needs data types from the schema object
+    dtype = {c.name: c.type for c in schema_obj.__table__.columns}
+    # Pandas doesn't play nice with types
+    insert_df.to_sql(
+        table_name,
+        con=session.connection(),
+        if_exists="append",
+        method="multi",
+        index=False,
+        dtype=dtype,  # type: ignore
+    )
     # commit the transaction
     try:
         session.commit()

--- a/lib/chainsync/chainsync/db/base/interface.py
+++ b/lib/chainsync/chainsync/db/base/interface.py
@@ -69,7 +69,7 @@ def initialize_engine(postgres_config: PostgresConfig | None = None) -> Engine:
         postgres_config = build_postgres_config()
 
     url_object = URL.create(
-        drivername="postgresql",
+        drivername="postgresql+psycopg",
         username=postgres_config.POSTGRES_USER,
         password=postgres_config.POSTGRES_PASSWORD,
         host=postgres_config.POSTGRES_HOST,

--- a/lib/chainsync/chainsync/test_fixtures/db_session.py
+++ b/lib/chainsync/chainsync/test_fixtures/db_session.py
@@ -29,14 +29,14 @@ def psql_docker() -> Iterator[PostgresConfig]:
 
     container = client.containers.run(
         # TODO set to latest postgres (what's being used in infra)
-        image="postgres:12",
+        image="postgres",
         auto_remove=True,
         environment={
             "POSTGRES_USER": postgres_config.POSTGRES_USER,
             "POSTGRES_PASSWORD": postgres_config.POSTGRES_PASSWORD,
         },
         name="test_postgres",
-        ports={"5432/tcp": ("127.0.0.1", postgres_config.POSTGRES_PORT)},
+        ports={"5432/tcp": ("localhost", postgres_config.POSTGRES_PORT)},
         detach=True,
         remove=True,
     )
@@ -62,7 +62,7 @@ def database_engine(psql_docker):
         port=postgres_config.POSTGRES_PORT,
         dbname=postgres_config.POSTGRES_DB,
         # TODO set to latest postgres (what's being used in infra)
-        version=12,
+        version="latest",
         password=postgres_config.POSTGRES_PASSWORD,
     ):
         engine = initialize_engine(postgres_config)

--- a/lib/chainsync/pyproject.toml
+++ b/lib/chainsync/pyproject.toml
@@ -33,7 +33,7 @@ base = [
     "streamlit",
     "flask",
     "flask-expects-json",
-    "psycopg2-binary",
+    "psycopg[binary]",
     "sqlalchemy",
     "pandas-stubs",
 ]


### PR DESCRIPTION
This fixes a couple of bugs in the postgres connection:

- Adding psycopg3 needed by `pytest_postgresql` (previously working due to existing postgres installation in environment)
- Now using psycopg3 for all connections to postgres container
- Using latest postgres in tests (matching what's done in infra)
- Fixing port bind for docker