### PR TITLE
add a hyperdrive api

### DIFF
--- a/lib/agent0/agent0/hyperdrive/exec/__init__.py
+++ b/lib/agent0/agent0/hyperdrive/exec/__init__.py
@@ -2,7 +2,6 @@
 from .crash_report import setup_hyperdrive_crash_report_logging
 from .create_and_fund_user_account import create_and_fund_user_account
 from .execute_agent_trades import (
-    ReceiptBreakdown,
     async_execute_agent_trades,
     async_execute_single_agent_trade,
     async_match_contract_call_to_trade,

--- a/lib/agent0/agent0/hyperdrive/exec/__init__.py
+++ b/lib/agent0/agent0/hyperdrive/exec/__init__.py
@@ -5,8 +5,6 @@ from .execute_agent_trades import (
     async_execute_agent_trades,
     async_execute_single_agent_trade,
     async_match_contract_call_to_trade,
-    async_smart_contract_transact,
-    async_transact_and_parse_logs,
 )
 from .fund_agents import fund_agents
 from .get_agent_accounts import get_agent_accounts

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -21,6 +21,8 @@ from ethpy.base import (
 )
 from ethpy.hyperdrive import ReceiptBreakdown, get_hyperdrive_market, parse_logs
 from ethpy.hyperdrive.api import HyperdriveInterface
+from ethpy.base import UnknownBlockError, async_smart_contract_transact, smart_contract_preview_transaction
+from ethpy.hyperdrive import HyperdriveInterface, ReceiptBreakdown, get_hyperdrive_market, parse_logs
 from fixedpointmath import FixedPoint
 from web3 import Web3
 from web3.contract.contract import Contract
@@ -141,13 +143,10 @@ async def async_match_contract_call_to_trade(
     hyperdrive_contract: Contract,
     agent: HyperdriveAgent,
     trade_envelope: types.Trade[HyperdriveMarketAction],
-<<<<<<< HEAD
     hyperdrive: Hyperdrive | None = None,  # FIXME: Optional for now, to test out Hyperdrive API
 ) -> HyperdriveWalletDeltas:
-=======
     hyperdrive: HyperdriveInterface | None = None,  # FIXME: Optional for now, to test out Hyperdrive API
 ) -> WalletDeltas:
->>>>>>> 9453b16b (first attempt at a test (fails))
     """Match statement that executes the smart contract trade based on the provided type.
 
     Arguments

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -21,6 +21,7 @@ from ethpy.hyperdrive import get_hyperdrive_market
 from fixedpointmath import FixedPoint
 from web3 import Web3
 from web3.contract.contract import Contract
+from web3.types import TxReceipt
 
 if TYPE_CHECKING:
     from agent0.hyperdrive.agents import HyperdriveAgent
@@ -63,6 +64,57 @@ class ReceiptBreakdown:
             )
 
 
+def parse_logs(tx_receipt: TxReceipt, hyperdrive_contract: Contract, fn_name: str) -> ReceiptBreakdown:
+    """Decode a Hyperdrive contract transaction receipt to get the changes to the agent's funds.
+
+    Arguments
+    ---------
+    TxReceipt
+        a TypedDict; success can be checked via tx_receipt["status"]
+    hyperdrive_contract : Contract
+        Any deployed web3 contract
+    fn_name : str
+        This function must exist in the compiled contract's ABI
+
+    Returns
+    -------
+    ReceiptBreakdown
+        A dataclass containing the maturity time and the absolute values for token quantities changed
+    """
+    # Sometimes, smart contract transact fails with status 0 with no error message
+    # We throw custom error to catch in trades loop, ignore, and move on
+    # TODO need to track down why this call fails and handle better
+    status = tx_receipt.get("status", None)
+    if status is None:
+        raise AssertionError("Receipt did not return status")
+    if status == 0:
+        raise UnknownBlockError(f"Receipt has no status or status is 0 \n {tx_receipt=}")
+    hyperdrive_event_logs = get_transaction_logs(
+        hyperdrive_contract,
+        tx_receipt,
+        event_names=[fn_name[0].capitalize() + fn_name[1:]],
+    )
+    if len(hyperdrive_event_logs) == 0:
+        raise AssertionError(f"Transaction receipt had no logs\ntx_receipt=\n{tx_receipt}")
+    if len(hyperdrive_event_logs) > 1:
+        raise AssertionError("Too many logs found")
+    log_args = hyperdrive_event_logs[0]["args"]
+    trade_result = ReceiptBreakdown()
+    if "assetId" in log_args:
+        trade_result.asset_id = log_args["assetId"]
+    if "maturityTime" in log_args:
+        trade_result.maturity_time_seconds = log_args["maturityTime"]
+    if "baseAmount" in log_args:
+        trade_result.base_amount = FixedPoint(scaled_value=log_args["baseAmount"])
+    if "bondAmount" in log_args:
+        trade_result.bond_amount = FixedPoint(scaled_value=log_args["bondAmount"])
+    if "lpAmount" in log_args:
+        trade_result.lp_amount = FixedPoint(scaled_value=log_args["lpAmount"])
+    if "withdrawalShareAmount" in log_args:
+        trade_result.withdrawal_share_amount = FixedPoint(scaled_value=log_args["withdrawalShareAmount"])
+    return trade_result
+
+
 async def async_transact_and_parse_logs(
     web3: Web3, hyperdrive_contract: Contract, signer: HyperdriveAgent, fn_name: str, *fn_args
 ) -> ReceiptBreakdown:
@@ -87,39 +139,7 @@ async def async_transact_and_parse_logs(
         A dataclass containing the maturity time and the absolute values for token quantities changed
     """
     tx_receipt = await async_smart_contract_transact(web3, hyperdrive_contract, signer, fn_name, *fn_args)
-    # Sometimes, smart contract transact fails with status 0 with no error message
-    # We throw custom error to catch in trades loop, ignore, and move on
-    # TODO need to track down why this call fails and handle better
-    status = tx_receipt.get("status", None)
-    if status is None:
-        raise AssertionError("Receipt did not return status")
-    if status == 0:
-        raise UnknownBlockError(f"Receipt has no status or status is 0 \n {tx_receipt=}")
-
-    hyperdrive_event_logs = get_transaction_logs(
-        hyperdrive_contract,
-        tx_receipt,
-        event_names=[fn_name[0].capitalize() + fn_name[1:]],
-    )
-
-    if len(hyperdrive_event_logs) == 0:
-        raise AssertionError(f"Transaction receipt had no logs\ntx_receipt=\n{tx_receipt}")
-    if len(hyperdrive_event_logs) > 1:
-        raise AssertionError("Too many logs found")
-    log_args = hyperdrive_event_logs[0]["args"]
-    trade_result = ReceiptBreakdown()
-    if "assetId" in log_args:
-        trade_result.asset_id = log_args["assetId"]
-    if "maturityTime" in log_args:
-        trade_result.maturity_time_seconds = log_args["maturityTime"]
-    if "baseAmount" in log_args:
-        trade_result.base_amount = FixedPoint(scaled_value=log_args["baseAmount"])
-    if "bondAmount" in log_args:
-        trade_result.bond_amount = FixedPoint(scaled_value=log_args["bondAmount"])
-    if "lpAmount" in log_args:
-        trade_result.lp_amount = FixedPoint(scaled_value=log_args["lpAmount"])
-    if "withdrawalShareAmount" in log_args:
-        trade_result.withdrawal_share_amount = FixedPoint(scaled_value=log_args["withdrawalShareAmount"])
+    trade_result = parse_logs(tx_receipt, hyperdrive_contract, fn_name)
     return trade_result
 
 

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -343,6 +343,7 @@ async def async_match_contract_call_to_trade(
             )
 
         case HyperdriveActionType.CLOSE_SHORT:
+<<<<<<< HEAD
             if not trade.maturity_time:
                 raise ValueError("Maturity time was not provided, can't close long position.")
             maturity_time_seconds = trade.maturity_time
@@ -370,6 +371,40 @@ async def async_match_contract_call_to_trade(
                 *fn_args,
             )
             wallet_deltas = HyperdriveWalletDeltas(
+=======
+            if not trade.mint_time:
+                raise ValueError("Mint time was not provided, can't close long position.")
+            if hyperdrive is None:  # FIXME: temp until api is finished
+                maturity_time_seconds = int(trade.mint_time)
+                min_output = 0
+                fn_args = (
+                    maturity_time_seconds,
+                    trade_amount,
+                    min_output,
+                    agent.checksum_address,
+                    as_underlying,
+                )
+                if trade.slippage_tolerance:
+                    preview_result = smart_contract_preview_transaction(
+                        hyperdrive_contract, agent.checksum_address, "closeShort", *fn_args
+                    )
+                    min_output = (
+                        FixedPoint(scaled_value=preview_result["value"]) * (FixedPoint(1) - trade.slippage_tolerance)
+                    ).scaled_value
+                    fn_args = (maturity_time_seconds, trade_amount, min_output, agent.checksum_address, as_underlying)
+                trade_result = await async_transact_and_parse_logs(
+                    web3,
+                    hyperdrive_contract,
+                    agent,
+                    "closeShort",
+                    *fn_args,
+                )
+            else:
+                trade_result = await hyperdrive.async_close_short(
+                    agent, trade.trade_amount, trade.mint_time, trade.slippage_tolerance
+                )
+            wallet_deltas = WalletDeltas(
+>>>>>>> e0a7fec6 (close short)
                 balance=Quantity(
                     amount=trade_result.base_amount,
                     unit=TokenType.BASE,

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -146,6 +146,7 @@ async def async_match_contract_call_to_trade(
     hyperdrive: Hyperdrive | None = None,  # FIXME: Optional for now, to test out Hyperdrive API
 ) -> HyperdriveWalletDeltas:
     hyperdrive: HyperdriveInterface | None = None,  # FIXME: Optional for now, to test out Hyperdrive API
+    hyperdrive: HyperdriveInterface | None = None,  # FIXME: Optional for now, should be required
 ) -> WalletDeltas:
     """Match statement that executes the smart contract trade based on the provided type.
 
@@ -427,7 +428,9 @@ async def async_match_contract_call_to_trade(
                     *fn_args,
                 )
             else:
-                trade_result = await hyperdrive.async_add_liquidity(agent, trade.trade_amount, min_apr, max_apr)
+                trade_result = await hyperdrive.async_add_liquidity(
+                    agent, trade.trade_amount, FixedPoint(min_apr), FixedPoint(max_apr)
+                )
             wallet_deltas = WalletDeltas(
                 balance=Quantity(
                     amount=-trade_result.base_amount,

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -198,19 +198,15 @@ async def async_match_contract_call_to_trade(
                     *fn_args,
                 )
             else:
-<<<<<<< HEAD
                 trade_result = await hyperdrive.async_open_long(trade_amount, agent, trade.slippage_tolerance)
             maturity_time_seconds = trade_result.maturity_time_seconds
             wallet_deltas = HyperdriveWalletDeltas(
-=======
                 trade_result = await hyperdrive.async_open_long(agent, trade.trade_amount, trade.slippage_tolerance)
             wallet_deltas = WalletDeltas(
->>>>>>> 534d2e53 (adds close long)
                 balance=Quantity(
                     amount=-trade_result.base_amount,
                     unit=TokenType.BASE,
                 ),
-<<<<<<< HEAD
                 longs={maturity_time_seconds: Long(trade_result.bond_amount)},
             )
 
@@ -242,7 +238,6 @@ async def async_match_contract_call_to_trade(
                 *fn_args,
             )
             wallet_deltas = HyperdriveWalletDeltas(
-=======
                 longs={FixedPoint(trade_result.maturity_time_seconds): Long(trade_result.bond_amount)},
             )
 
@@ -279,7 +274,6 @@ async def async_match_contract_call_to_trade(
                     agent, trade.trade_amount, trade.mint_time, trade.slippage_tolerance
                 )
             wallet_deltas = WalletDeltas(
->>>>>>> 534d2e53 (adds close long)
                 balance=Quantity(
                     amount=trade_result.base_amount,
                     unit=TokenType.BASE,
@@ -307,7 +301,6 @@ async def async_match_contract_call_to_trade(
                     "openShort",
                     *fn_args,
                 )
-<<<<<<< HEAD
                 max_deposit = (
                     FixedPoint(scaled_value=preview_result["traderDeposit"])
                     * (FixedPoint(1) + trade.slippage_tolerance)
@@ -322,28 +315,22 @@ async def async_match_contract_call_to_trade(
             )
             maturity_time_seconds = trade_result.maturity_time_seconds
             wallet_deltas = HyperdriveWalletDeltas(
-=======
             else:
                 trade_result = await hyperdrive.async_open_short(agent, trade.trade_amount, trade.slippage_tolerance)
             wallet_deltas = WalletDeltas(
->>>>>>> 6bed08f9 (open short)
                 balance=Quantity(
                     amount=-trade_result.base_amount,
                     unit=TokenType.BASE,
                 ),
                 shorts={
-<<<<<<< HEAD
                     maturity_time_seconds: Short(
-=======
                     FixedPoint(trade_result.maturity_time_seconds): Short(
->>>>>>> 6bed08f9 (open short)
                         balance=trade_result.bond_amount,
                     )
                 },
             )
 
         case HyperdriveActionType.CLOSE_SHORT:
-<<<<<<< HEAD
             if not trade.maturity_time:
                 raise ValueError("Maturity time was not provided, can't close long position.")
             maturity_time_seconds = trade.maturity_time
@@ -371,7 +358,6 @@ async def async_match_contract_call_to_trade(
                 *fn_args,
             )
             wallet_deltas = HyperdriveWalletDeltas(
-=======
             if not trade.mint_time:
                 raise ValueError("Mint time was not provided, can't close long position.")
             if hyperdrive is None:  # FIXME: temp until api is finished
@@ -404,7 +390,6 @@ async def async_match_contract_call_to_trade(
                     agent, trade.trade_amount, trade.mint_time, trade.slippage_tolerance
                 )
             wallet_deltas = WalletDeltas(
->>>>>>> e0a7fec6 (close short)
                 balance=Quantity(
                     amount=trade_result.base_amount,
                     unit=TokenType.BASE,
@@ -417,7 +402,6 @@ async def async_match_contract_call_to_trade(
             )
 
         case HyperdriveActionType.ADD_LIQUIDITY:
-<<<<<<< HEAD
             min_output = 0
             fn_args = (trade_amount, min_apr, max_apr, agent.checksum_address, as_underlying)
             trade_result = await async_transact_and_parse_logs(
@@ -428,7 +412,6 @@ async def async_match_contract_call_to_trade(
                 *fn_args,
             )
             wallet_deltas = HyperdriveWalletDeltas(
-=======
             if hyperdrive is None:  # FIXME: temp until api is finished
                 min_output = 0
                 fn_args = (trade_amount, min_apr, max_apr, agent.checksum_address, as_underlying)
@@ -442,7 +425,6 @@ async def async_match_contract_call_to_trade(
             else:
                 trade_result = await hyperdrive.async_add_liquidity(agent, trade.trade_amount, min_apr, max_apr)
             wallet_deltas = WalletDeltas(
->>>>>>> f1eff591 (add liquidity)
                 balance=Quantity(
                     amount=-trade_result.base_amount,
                     unit=TokenType.BASE,
@@ -451,7 +433,6 @@ async def async_match_contract_call_to_trade(
             )
 
         case HyperdriveActionType.REMOVE_LIQUIDITY:
-<<<<<<< HEAD
             min_output = 0
             fn_args = (trade_amount, min_output, agent.checksum_address, as_underlying)
             trade_result = await async_transact_and_parse_logs(
@@ -462,7 +443,6 @@ async def async_match_contract_call_to_trade(
                 *fn_args,
             )
             wallet_deltas = HyperdriveWalletDeltas(
-=======
             if hyperdrive is None:  # FIXME: temp until api is finished
                 min_output = 0
                 fn_args = (trade_amount, min_output, agent.checksum_address, as_underlying)
@@ -476,7 +456,6 @@ async def async_match_contract_call_to_trade(
             else:
                 trade_result = await hyperdrive.async_remove_liquidity(agent, trade.trade_amount)
             wallet_deltas = WalletDeltas(
->>>>>>> 18740350 (remove liquidity)
                 balance=Quantity(
                     amount=trade_result.base_amount,
                     unit=TokenType.BASE,
@@ -501,6 +480,24 @@ async def async_match_contract_call_to_trade(
                 *fn_args,
             )
             wallet_deltas = HyperdriveWalletDeltas(
+            if hyperdrive is None:  # FIXME: temp until api is finished
+                # for now, assume an underlying vault share price of at least 1, should be higher by a bit
+                min_output = FixedPoint(1)
+                # NOTE: This is not guaranteed to redeem all shares.  The pool will try to redeem as
+                # many as possible, up to the withdrawPool.readyToRedeem limit, without reverting.  Only
+                # a min_output that is too high will cause a revert here, or trying to withdraw more
+                # shares than the user has obviously.
+                fn_args = (trade_amount, min_output.scaled_value, agent.checksum_address, as_underlying)
+                trade_result = await async_transact_and_parse_logs(
+                    web3,
+                    hyperdrive_contract,
+                    agent,
+                    "redeemWithdrawalShares",
+                    *fn_args,
+                )
+            else:
+                trade_result = await hyperdrive.async_redeem_withdraw_shares(agent, trade.trade_amount)
+            wallet_deltas = WalletDeltas(
                 balance=Quantity(
                     amount=trade_result.base_amount,
                     unit=TokenType.BASE,

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -20,7 +20,7 @@ from ethpy.base import (
     smart_contract_preview_transaction,
 )
 from ethpy.hyperdrive import ReceiptBreakdown, get_hyperdrive_market, parse_logs
-from ethpy.hyperdrive.api import Hyperdrive
+from ethpy.hyperdrive.api import HyperdriveInterface
 from fixedpointmath import FixedPoint
 from web3 import Web3
 from web3.contract.contract import Contract
@@ -141,8 +141,13 @@ async def async_match_contract_call_to_trade(
     hyperdrive_contract: Contract,
     agent: HyperdriveAgent,
     trade_envelope: types.Trade[HyperdriveMarketAction],
+<<<<<<< HEAD
     hyperdrive: Hyperdrive | None = None,  # FIXME: Optional for now, to test out Hyperdrive API
 ) -> HyperdriveWalletDeltas:
+=======
+    hyperdrive: HyperdriveInterface | None = None,  # FIXME: Optional for now, to test out Hyperdrive API
+) -> WalletDeltas:
+>>>>>>> 9453b16b (first attempt at a test (fails))
     """Match statement that executes the smart contract trade based on the provided type.
 
     Arguments

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -417,6 +417,7 @@ async def async_match_contract_call_to_trade(
             )
 
         case HyperdriveActionType.ADD_LIQUIDITY:
+<<<<<<< HEAD
             min_output = 0
             fn_args = (trade_amount, min_apr, max_apr, agent.checksum_address, as_underlying)
             trade_result = await async_transact_and_parse_logs(
@@ -427,6 +428,21 @@ async def async_match_contract_call_to_trade(
                 *fn_args,
             )
             wallet_deltas = HyperdriveWalletDeltas(
+=======
+            if hyperdrive is None:  # FIXME: temp until api is finished
+                min_output = 0
+                fn_args = (trade_amount, min_apr, max_apr, agent.checksum_address, as_underlying)
+                trade_result = await async_transact_and_parse_logs(
+                    web3,
+                    hyperdrive_contract,
+                    agent,
+                    "addLiquidity",
+                    *fn_args,
+                )
+            else:
+                trade_result = await hyperdrive.async_add_liquidity(agent, trade.trade_amount, min_apr, max_apr)
+            wallet_deltas = WalletDeltas(
+>>>>>>> f1eff591 (add liquidity)
                 balance=Quantity(
                     amount=-trade_result.base_amount,
                     unit=TokenType.BASE,

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -108,9 +108,6 @@ async def async_match_contract_call_to_trade(
     # TODO: figure out fees paid
     # pylint: disable=too-many-statements
     trade = trade_envelope.market_action
-    # TODO: The following variables are hard coded for now, but should be specified in the trade spec
-    min_apr = int(1)
-    max_apr = FixedPoint(1).scaled_value
     match trade.action_type:
         case HyperdriveActionType.INITIALIZE_MARKET:
             raise ValueError(f"{trade.action_type} not supported!")
@@ -164,9 +161,10 @@ async def async_match_contract_call_to_trade(
             )
 
         case HyperdriveActionType.ADD_LIQUIDITY:
-            trade_result = await hyperdrive.async_add_liquidity(
-                agent, trade.trade_amount, FixedPoint(min_apr), FixedPoint(max_apr)
-            )
+            # TODO: The following variables are hard coded for now, but should be specified in the trade spec
+            min_apr = FixedPoint(scaled_value=1)  # 1e-18
+            max_apr = FixedPoint(1)  # 1.0
+            trade_result = await hyperdrive.async_add_liquidity(agent, trade.trade_amount, min_apr, max_apr)
             wallet_deltas = HyperdriveWalletDeltas(
                 balance=Quantity(
                     amount=-trade_result.base_amount,

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -288,12 +288,26 @@ async def async_match_contract_call_to_trade(
             )
 
         case HyperdriveActionType.OPEN_SHORT:
-            max_deposit = eth_utils.currency.MAX_WEI
-            fn_args = (trade_amount, max_deposit, agent.checksum_address, as_underlying)
-            if trade.slippage_tolerance:
-                preview_result = smart_contract_preview_transaction(
-                    hyperdrive_contract, agent.checksum_address, "openShort", *fn_args
+            if hyperdrive is None:  # FIXME: temp until api is finished
+                max_deposit = eth_utils.currency.MAX_WEI
+                fn_args = (trade_amount, max_deposit, agent.checksum_address, as_underlying)
+                if trade.slippage_tolerance:
+                    preview_result = smart_contract_preview_transaction(
+                        hyperdrive_contract, agent.checksum_address, "openShort", *fn_args
+                    )
+                    max_deposit = (
+                        FixedPoint(scaled_value=preview_result["traderDeposit"])
+                        * (FixedPoint(1) + trade.slippage_tolerance)
+                    ).scaled_value
+                fn_args = (trade_amount, max_deposit, agent.checksum_address, as_underlying)
+                trade_result = await async_transact_and_parse_logs(
+                    web3,
+                    hyperdrive_contract,
+                    agent,
+                    "openShort",
+                    *fn_args,
                 )
+<<<<<<< HEAD
                 max_deposit = (
                     FixedPoint(scaled_value=preview_result["traderDeposit"])
                     * (FixedPoint(1) + trade.slippage_tolerance)
@@ -308,12 +322,21 @@ async def async_match_contract_call_to_trade(
             )
             maturity_time_seconds = trade_result.maturity_time_seconds
             wallet_deltas = HyperdriveWalletDeltas(
+=======
+            else:
+                trade_result = await hyperdrive.async_open_short(agent, trade.trade_amount, trade.slippage_tolerance)
+            wallet_deltas = WalletDeltas(
+>>>>>>> 6bed08f9 (open short)
                 balance=Quantity(
                     amount=-trade_result.base_amount,
                     unit=TokenType.BASE,
                 ),
                 shorts={
+<<<<<<< HEAD
                     maturity_time_seconds: Short(
+=======
+                    FixedPoint(trade_result.maturity_time_seconds): Short(
+>>>>>>> 6bed08f9 (open short)
                         balance=trade_result.bond_amount,
                     )
                 },

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -451,6 +451,7 @@ async def async_match_contract_call_to_trade(
             )
 
         case HyperdriveActionType.REMOVE_LIQUIDITY:
+<<<<<<< HEAD
             min_output = 0
             fn_args = (trade_amount, min_output, agent.checksum_address, as_underlying)
             trade_result = await async_transact_and_parse_logs(
@@ -461,6 +462,21 @@ async def async_match_contract_call_to_trade(
                 *fn_args,
             )
             wallet_deltas = HyperdriveWalletDeltas(
+=======
+            if hyperdrive is None:  # FIXME: temp until api is finished
+                min_output = 0
+                fn_args = (trade_amount, min_output, agent.checksum_address, as_underlying)
+                trade_result = await async_transact_and_parse_logs(
+                    web3,
+                    hyperdrive_contract,
+                    agent,
+                    "removeLiquidity",
+                    *fn_args,
+                )
+            else:
+                trade_result = await hyperdrive.async_remove_liquidity(agent, trade.trade_amount)
+            wallet_deltas = WalletDeltas(
+>>>>>>> 18740350 (remove liquidity)
                 balance=Quantity(
                     amount=trade_result.base_amount,
                     unit=TokenType.BASE,

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -198,13 +198,19 @@ async def async_match_contract_call_to_trade(
                     *fn_args,
                 )
             else:
+<<<<<<< HEAD
                 trade_result = await hyperdrive.async_open_long(trade_amount, agent, trade.slippage_tolerance)
             maturity_time_seconds = trade_result.maturity_time_seconds
             wallet_deltas = HyperdriveWalletDeltas(
+=======
+                trade_result = await hyperdrive.async_open_long(agent, trade.trade_amount, trade.slippage_tolerance)
+            wallet_deltas = WalletDeltas(
+>>>>>>> 534d2e53 (adds close long)
                 balance=Quantity(
                     amount=-trade_result.base_amount,
                     unit=TokenType.BASE,
                 ),
+<<<<<<< HEAD
                 longs={maturity_time_seconds: Long(trade_result.bond_amount)},
             )
 
@@ -236,6 +242,44 @@ async def async_match_contract_call_to_trade(
                 *fn_args,
             )
             wallet_deltas = HyperdriveWalletDeltas(
+=======
+                longs={FixedPoint(trade_result.maturity_time_seconds): Long(trade_result.bond_amount)},
+            )
+
+        case HyperdriveActionType.CLOSE_LONG:
+            if not trade.mint_time:
+                raise ValueError("Mint time was not provided, can't close long position.")
+            if hyperdrive is None:  # FIXME: temp until api is finished
+                maturity_time_seconds = int(trade.mint_time)
+                min_output = 0
+                fn_args = (
+                    maturity_time_seconds,
+                    trade_amount,
+                    min_output,
+                    agent.checksum_address,
+                    as_underlying,
+                )
+                if trade.slippage_tolerance:
+                    preview_result = smart_contract_preview_transaction(
+                        hyperdrive_contract, agent.checksum_address, "closeLong", *fn_args
+                    )
+                    min_output = (
+                        FixedPoint(scaled_value=preview_result["value"]) * (FixedPoint(1) - trade.slippage_tolerance)
+                    ).scaled_value
+                    fn_args = (maturity_time_seconds, trade_amount, min_output, agent.checksum_address, as_underlying)
+                trade_result = await async_transact_and_parse_logs(
+                    web3,
+                    hyperdrive_contract,
+                    agent,
+                    "closeLong",
+                    *fn_args,
+                )
+            else:
+                trade_result = await hyperdrive.async_close_long(
+                    agent, trade.trade_amount, trade.mint_time, trade.slippage_tolerance
+                )
+            wallet_deltas = WalletDeltas(
+>>>>>>> 534d2e53 (adds close long)
                 balance=Quantity(
                     amount=trade_result.base_amount,
                     unit=TokenType.BASE,

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -16,9 +16,6 @@ from fixedpointmath import FixedPoint
 if TYPE_CHECKING:
     from agent0.hyperdrive.agents import HyperdriveAgent
 
-# TODO: Fix these up when we refactor this file
-# pylint: disable=too-many-locals
-
 
 def assert_never(arg: NoReturn) -> NoReturn:
     """Helper function for exhaustive matching on ENUMS.
@@ -106,7 +103,6 @@ async def async_match_contract_call_to_trade(
 
     """
     # TODO: figure out fees paid
-    # pylint: disable=too-many-statements
     trade = trade_envelope.market_action
     match trade.action_type:
         case HyperdriveActionType.INITIALIZE_MARKET:
@@ -124,7 +120,7 @@ async def async_match_contract_call_to_trade(
 
         case HyperdriveActionType.CLOSE_LONG:
             if not trade.maturity_time:
-                raise ValueError("Mint time was not provided, can't close long position.")
+                raise ValueError("Maturity time was not provided, can't close long position.")
             trade_result = await hyperdrive.async_close_long(
                 agent, trade.trade_amount, trade.maturity_time, trade.slippage_tolerance
             )
@@ -148,7 +144,7 @@ async def async_match_contract_call_to_trade(
 
         case HyperdriveActionType.CLOSE_SHORT:
             if not trade.maturity_time:
-                raise ValueError("Mint time was not provided, can't close long position.")
+                raise ValueError("Maturity time was not provided, can't close long position.")
             trade_result = await hyperdrive.async_close_short(
                 agent, trade.trade_amount, trade.maturity_time, trade.slippage_tolerance
             )

--- a/lib/agent0/agent0/hyperdrive/exec/run_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/run_agents.py
@@ -5,15 +5,23 @@ import logging
 import os
 import warnings
 
+import pandas as pd
 from agent0 import AccountKeyConfig
+from agent0.base import Quantity, TokenType
 from agent0.base.config import DEFAULT_USERNAME, AgentConfig, EnvironmentConfig
+from agent0.hyperdrive.state import HyperdriveWallet, Long, Short
+from chainsync.db.api import balance_of, register_username
 from eth_typing import BlockNumber
 from ethpy import EthConfig, build_eth_config
+from ethpy.base import smart_contract_read
 from ethpy.hyperdrive import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
+from fixedpointmath import FixedPoint
+from hexbytes import HexBytes
+from web3.contract.contract import Contract
 
 from .create_and_fund_user_account import create_and_fund_user_account
 from .fund_agents import fund_agents
-from .setup_experiment import register_username, setup_experiment
+from .setup_experiment import setup_experiment
 from .trade_loop import trade_if_new_block
 
 
@@ -67,18 +75,32 @@ def run_agents(
     hyperdrive, agent_accounts = setup_experiment(
         eth_config, environment_config, agent_config, account_key_config, contract_addresses
     )
+    wallet_addrs = [str(agent.checksum_address) for agent in agent_accounts]
     # set up database
     if not develop:
+        # Ignore this check if not develop
         if environment_config.username == DEFAULT_USERNAME:
             # Check for default name and exit if is default
             raise ValueError(
                 "Default username detected, please update 'username' in "
                 "lib/agent0/agent0/hyperdrive/config/runner_config.py"
             )
-        # Set up postgres to write username to agent wallet addr
-        # initialize the postgres session
-        wallet_addrs = [str(agent.checksum_address) for agent in agent_accounts]
-        register_username(environment_config.username_register_uri, wallet_addrs, environment_config.username)
+        # Register wallet addresses to username
+        register_username(environment_config.database_api_uri, wallet_addrs, environment_config.username)
+    # Load existing balances
+    # Get existing open positions from db api server
+    balances = balance_of(environment_config.database_api_uri, wallet_addrs)
+    # Set balances of wallets based on db and chain
+    for agent in agent_accounts:
+        # TODO is this the right location for this to happen?
+        # On one hand, doing it here makes sense because parameters such as db uri doesn't have to
+        # be passed in down all the function calls when wallets are initialized.
+        # On the other hand, we initialize empty wallets just to overwrite here.
+        # Keeping here for now for later discussion
+        # TODO maybe this should be optional?
+        agent.wallet = build_wallet_positions_from_data(
+            agent.checksum_address, balances, hyperdrive.base_token_contract
+        )
     # run the trades
     last_executed_block = BlockNumber(0)
     while True:
@@ -88,3 +110,67 @@ def run_agents(
             environment_config.halt_on_errors,
             last_executed_block,
         )
+
+
+def build_wallet_positions_from_data(
+    wallet_addr: str, db_balances: pd.DataFrame, base_contract: Contract
+) -> HyperdriveWallet:
+    """Builds a wallet position based on gathered data.
+
+    Arguments
+    ---------
+    wallet_addr: str
+        The checksum wallet address
+    db_balances: pd.DataFrame
+        The current positions dataframe gathered from the db (from the `balance_of` api call)
+    base_contract: Contract
+        The base contract to query the base amount from
+
+    Returns
+    -------
+    HyperdriveWallet
+        The wallet object build from the provided data
+    """
+    # Contract call to get base balance
+    base_amount: dict[str, int] = smart_contract_read(base_contract, "balanceOf", wallet_addr)
+    # TODO do we need to do error checking here?
+    assert "value" in base_amount
+    base_obj = Quantity(amount=FixedPoint(scaled_value=base_amount["value"]), unit=TokenType.BASE)
+
+    # TODO We can also get lp and withdraw shares from chain?
+    wallet_balances = db_balances[db_balances["walletAddress"] == wallet_addr]
+
+    # Get longs
+    long_balances = wallet_balances[wallet_balances["baseTokenType"] == "LONG"]
+    long_obj = {}
+    for _, row in long_balances.iterrows():
+        long_obj[row["maturityTime"]] = Long(balance=FixedPoint(row["value"]))
+
+    short_balances = wallet_balances[wallet_balances["baseTokenType"] == "SHORT"]
+    short_obj = {}
+    for _, row in short_balances.iterrows():
+        short_obj[row["maturityTime"]] = Short(balance=FixedPoint(row["value"]))
+
+    lp_balances = wallet_balances[wallet_balances["baseTokenType"] == "LP"]
+    assert len(lp_balances) <= 1
+    if len(lp_balances) == 0:
+        lp_obj = FixedPoint(0)
+    else:
+        lp_obj = FixedPoint(lp_balances.iloc[0]["value"])
+
+    withdraw_balances = wallet_balances[wallet_balances["baseTokenType"] == "WITHDRAWAL_SHARE"]
+    assert len(withdraw_balances) <= 1
+    if len(withdraw_balances) == 0:
+        withdraw_obj = FixedPoint(0)
+    else:
+        withdraw_obj = FixedPoint(withdraw_balances.iloc[0]["value"])
+    # TODO Build withdraw share object
+
+    return HyperdriveWallet(
+        address=HexBytes(wallet_addr),
+        balance=base_obj,
+        lp_tokens=lp_obj,
+        withdraw_shares=withdraw_obj,
+        longs=long_obj,
+        shorts=short_obj,
+    )

--- a/lib/agent0/agent0/hyperdrive/exec/run_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/run_agents.py
@@ -78,7 +78,9 @@ def run_agents(
 
     wallet_addrs = [str(agent.checksum_address) for agent in agent_accounts]
     # get hyperdrive interface object and agents
-    hyperdrive, agent_accounts = setup_experiment(eth_config, environment_config, agent_config, account_key_config)
+    hyperdrive, agent_accounts = setup_experiment(
+        eth_config, environment_config, agent_config, account_key_config, contract_addresses
+    )
     # set up database
     if not develop:
         # Ignore this check if not develop

--- a/lib/agent0/agent0/hyperdrive/exec/run_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/run_agents.py
@@ -5,23 +5,15 @@ import logging
 import os
 import warnings
 
-import pandas as pd
 from agent0 import AccountKeyConfig
-from agent0.base import Quantity, TokenType
 from agent0.base.config import DEFAULT_USERNAME, AgentConfig, EnvironmentConfig
-from agent0.hyperdrive.state import HyperdriveWallet, Long, Short
-from chainsync.db.api import balance_of, register_username
 from eth_typing import BlockNumber
 from ethpy import EthConfig, build_eth_config
-from ethpy.base import smart_contract_read
 from ethpy.hyperdrive import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
-from fixedpointmath import FixedPoint
-from hexbytes import HexBytes
-from web3.contract.contract import Contract
 
 from .create_and_fund_user_account import create_and_fund_user_account
 from .fund_agents import fund_agents
-from .setup_experiment import setup_experiment
+from .setup_experiment import register_username, setup_experiment
 from .trade_loop import trade_if_new_block
 
 
@@ -71,41 +63,18 @@ def run_agents(
         fund_agents(
             user_account, eth_config, account_key_config, contract_addresses
         )  # uses env variables created above as inputs
-
-    web3, base_contract, hyperdrive_contract, agent_accounts = setup_experiment(
-        eth_config, environment_config, agent_config, account_key_config, contract_addresses
-    )
-
-    wallet_addrs = [str(agent.checksum_address) for agent in agent_accounts]
     # get hyperdrive interface object and agents
     hyperdrive, agent_accounts = setup_experiment(
         eth_config, environment_config, agent_config, account_key_config, contract_addresses
     )
     # set up database
     if not develop:
-        # Ignore this check if not develop
         if environment_config.username == DEFAULT_USERNAME:
             # Check for default name and exit if is default
             raise ValueError(
                 "Default username detected, please update 'username' in "
                 "lib/agent0/agent0/hyperdrive/config/runner_config.py"
             )
-        # Register wallet addresses to username
-        register_username(environment_config.database_api_uri, wallet_addrs, environment_config.username)
-
-    # Load existing balances
-    # Get existing open positions from db api server
-    balances = balance_of(environment_config.database_api_uri, wallet_addrs)
-    # Set balances of wallets based on db and chain
-    for agent in agent_accounts:
-        # TODO is this the right location for this to happen?
-        # On one hand, doing it here makes sense because parameters such as db uri doesn't have to
-        # be passed in down all the function calls when wallets are initialized.
-        # On the other hand, we initialize empty wallets just to overwrite here.
-        # Keeping here for now for later discussion
-        # TODO maybe this should be optional?
-        agent.wallet = build_wallet_positions_from_data(agent.checksum_address, balances, base_contract)
-
         # Set up postgres to write username to agent wallet addr
         # initialize the postgres session
         wallet_addrs = [str(agent.checksum_address) for agent in agent_accounts]
@@ -119,67 +88,3 @@ def run_agents(
             environment_config.halt_on_errors,
             last_executed_block,
         )
-
-
-def build_wallet_positions_from_data(
-    wallet_addr: str, db_balances: pd.DataFrame, base_contract: Contract
-) -> HyperdriveWallet:
-    """Builds a wallet position based on gathered data
-
-    Arguments
-    ---------
-    wallet_addr: str
-        The checksum wallet address
-    db_balances: pd.DataFrame
-        The current positions dataframe gathered from the db (from the `balance_of` api call)
-    base_contract: Contract
-        The base contract to query the base amount from
-
-    Returns
-    -------
-    HyperdriveWallet
-        The wallet object build from the provided data
-    """
-    # Contract call to get base balance
-    base_amount: dict[str, int] = smart_contract_read(base_contract, "balanceOf", wallet_addr)
-    # TODO do we need to do error checking here?
-    assert "value" in base_amount
-    base_obj = Quantity(amount=FixedPoint(scaled_value=base_amount["value"]), unit=TokenType.BASE)
-
-    # TODO We can also get lp and withdraw shares from chain?
-    wallet_balances = db_balances[db_balances["walletAddress"] == wallet_addr]
-
-    # Get longs
-    long_balances = wallet_balances[wallet_balances["baseTokenType"] == "LONG"]
-    long_obj = {}
-    for _, row in long_balances.iterrows():
-        long_obj[row["maturityTime"]] = Long(balance=FixedPoint(row["value"]))
-
-    short_balances = wallet_balances[wallet_balances["baseTokenType"] == "SHORT"]
-    short_obj = {}
-    for _, row in short_balances.iterrows():
-        short_obj[row["maturityTime"]] = Short(balance=FixedPoint(row["value"]))
-
-    lp_balances = wallet_balances[wallet_balances["baseTokenType"] == "LP"]
-    assert len(lp_balances) <= 1
-    if len(lp_balances) == 0:
-        lp_obj = FixedPoint(0)
-    else:
-        lp_obj = FixedPoint(lp_balances.iloc[0]["value"])
-
-    withdraw_balances = wallet_balances[wallet_balances["baseTokenType"] == "WITHDRAWAL_SHARE"]
-    assert len(withdraw_balances) <= 1
-    if len(withdraw_balances) == 0:
-        withdraw_obj = FixedPoint(0)
-    else:
-        withdraw_obj = FixedPoint(withdraw_balances.iloc[0]["value"])
-    # TODO Build withdraw share object
-
-    return HyperdriveWallet(
-        address=HexBytes(wallet_addr),
-        balance=base_obj,
-        lp_tokens=lp_obj,
-        withdraw_shares=withdraw_obj,
-        longs=long_obj,
-        shorts=short_obj,
-    )

--- a/lib/agent0/agent0/hyperdrive/exec/setup_experiment.py
+++ b/lib/agent0/agent0/hyperdrive/exec/setup_experiment.py
@@ -8,9 +8,7 @@ from agent0.hyperdrive.agents import HyperdriveAgent
 from agent0.hyperdrive.exec.crash_report import setup_hyperdrive_crash_report_logging
 from elfpy.utils import logs
 from ethpy import EthConfig
-from ethpy.hyperdrive import HyperdriveAddresses, get_web3_and_hyperdrive_contracts
-from web3 import Web3
-from web3.contract.contract import Contract
+from ethpy.hyperdrive import HyperdriveInterface
 
 from .get_agent_accounts import get_agent_accounts
 
@@ -20,8 +18,7 @@ def setup_experiment(
     environment_config: EnvironmentConfig,
     agent_config: list[AgentConfig],
     account_key_config: AccountKeyConfig,
-    contract_addresses: HyperdriveAddresses,
-) -> tuple[Web3, Contract, Contract, list[HyperdriveAgent]]:
+) -> tuple[HyperdriveInterface, list[HyperdriveAgent]]:
     """Get agents according to provided config, provide eth, base token and approve hyperdrive.
 
     Arguments
@@ -34,23 +31,17 @@ def setup_experiment(
         The list of agent configurations.
     account_key_config: AccountKeyConfig
         Configuration linking to the env file for storing private keys and initial budgets.
-    contract_addresses: HyperdriveAddresses
-        Configuration for defining various contract addresses.
 
     Returns
     -------
-    tuple[Web3, Contract, Contract, EnvironmentConfig, list[HyperdriveAgent]]
+    tuple[HyperdriveInterface, list[HyperdriveAgent]]
         A tuple containing:
-            - The web3 container
-            - The base token contract
-            - The hyperdrive contract
+            - The Hyperdrive interface API object
             - A list of HyperdriveAgent objects that contain a wallet address and Elfpy Agent for determining trades
     """
-
     # this random number generator should be used everywhere so that the experiment is repeatable
     # rng stores the state of the random number generator, so that we can pause and restart experiments from any point
     rng = np.random.default_rng(environment_config.random_seed)
-
     # setup logging
     logs.setup_logging(
         log_filename=environment_config.log_filename,
@@ -61,11 +52,37 @@ def setup_experiment(
         log_format_string=environment_config.log_formatter,
     )
     setup_hyperdrive_crash_report_logging()
-    web3, base_token_contract, hyperdrive_contract = get_web3_and_hyperdrive_contracts(eth_config, contract_addresses)
+    # create hyperdrive interface object
+    hyperdrive = HyperdriveInterface(eth_config)
     # load agent policies
     # rng is shared by the agents and can be accessed via `agent_accounts[idx].policy.rng`
     agent_accounts = get_agent_accounts(
-        web3, agent_config, account_key_config, base_token_contract, hyperdrive_contract.address, rng
+        hyperdrive.web3,
+        agent_config,
+        account_key_config,
+        hyperdrive.base_token_contract,
+        hyperdrive.hyperdrive_contract.address,
+        rng,
     )
 
     return web3, base_token_contract, hyperdrive_contract, agent_accounts
+    return hyperdrive, agent_accounts
+
+
+def register_username(register_uri: str, wallet_addrs: list[str], username: str) -> None:
+    """Registers the username with the flask server.
+
+    Arguments
+    ---------
+    register_uri: str
+        The endpoint for the flask server.
+    wallet_addrs: list[str]
+        The list of wallet addresses to register.
+    username: str
+        The username to register the wallet addresses under.
+    """
+    # TODO: use the json schema from the server.
+    json_data = {"wallet_addrs": wallet_addrs, "username": username}
+    result = requests.post(f"{register_uri}/register_agents", json=json_data, timeout=3)
+    if result.status_code != HTTPStatus.OK:
+        raise ConnectionError(result)

--- a/lib/agent0/agent0/hyperdrive/exec/setup_experiment.py
+++ b/lib/agent0/agent0/hyperdrive/exec/setup_experiment.py
@@ -8,7 +8,7 @@ from agent0.hyperdrive.agents import HyperdriveAgent
 from agent0.hyperdrive.exec.crash_report import setup_hyperdrive_crash_report_logging
 from elfpy.utils import logs
 from ethpy import EthConfig
-from ethpy.hyperdrive import HyperdriveInterface
+from ethpy.hyperdrive import HyperdriveAddresses, HyperdriveInterface
 
 from .get_agent_accounts import get_agent_accounts
 
@@ -18,6 +18,7 @@ def setup_experiment(
     environment_config: EnvironmentConfig,
     agent_config: list[AgentConfig],
     account_key_config: AccountKeyConfig,
+    contract_addresses: HyperdriveAddresses | None,
 ) -> tuple[HyperdriveInterface, list[HyperdriveAgent]]:
     """Get agents according to provided config, provide eth, base token and approve hyperdrive.
 
@@ -31,6 +32,8 @@ def setup_experiment(
         The list of agent configurations.
     account_key_config: AccountKeyConfig
         Configuration linking to the env file for storing private keys and initial budgets.
+    contract_addresses: HyperdriveAddresses, optional
+        Configuration for defining various contract addresses.
 
     Returns
     -------
@@ -53,7 +56,7 @@ def setup_experiment(
     )
     setup_hyperdrive_crash_report_logging()
     # create hyperdrive interface object
-    hyperdrive = HyperdriveInterface(eth_config)
+    hyperdrive = HyperdriveInterface(eth_config, contract_addresses)
     # load agent policies
     # rng is shared by the agents and can be accessed via `agent_accounts[idx].policy.rng`
     agent_accounts = get_agent_accounts(

--- a/lib/agent0/agent0/hyperdrive/exec/setup_experiment.py
+++ b/lib/agent0/agent0/hyperdrive/exec/setup_experiment.py
@@ -1,7 +1,10 @@
 """Setup helper function for running eth agent experiments."""
 from __future__ import annotations
 
+from http import HTTPStatus
+
 import numpy as np
+import requests
 from agent0 import AccountKeyConfig
 from agent0.base.config import AgentConfig, EnvironmentConfig
 from agent0.hyperdrive.agents import HyperdriveAgent
@@ -67,8 +70,6 @@ def setup_experiment(
         hyperdrive.hyperdrive_contract.address,
         rng,
     )
-
-    return web3, base_token_contract, hyperdrive_contract, agent_accounts
     return hyperdrive, agent_accounts
 
 

--- a/lib/agent0/agent0/hyperdrive/exec/setup_experiment.py
+++ b/lib/agent0/agent0/hyperdrive/exec/setup_experiment.py
@@ -1,10 +1,7 @@
 """Setup helper function for running eth agent experiments."""
 from __future__ import annotations
 
-from http import HTTPStatus
-
 import numpy as np
-import requests
 from agent0 import AccountKeyConfig
 from agent0.base.config import AgentConfig, EnvironmentConfig
 from agent0.hyperdrive.agents import HyperdriveAgent
@@ -71,22 +68,3 @@ def setup_experiment(
         rng,
     )
     return hyperdrive, agent_accounts
-
-
-def register_username(register_uri: str, wallet_addrs: list[str], username: str) -> None:
-    """Registers the username with the flask server.
-
-    Arguments
-    ---------
-    register_uri: str
-        The endpoint for the flask server.
-    wallet_addrs: list[str]
-        The list of wallet addresses to register.
-    username: str
-        The username to register the wallet addresses under.
-    """
-    # TODO: use the json schema from the server.
-    json_data = {"wallet_addrs": wallet_addrs, "username": username}
-    result = requests.post(f"{register_uri}/register_agents", json=json_data, timeout=3)
-    if result.status_code != HTTPStatus.OK:
-        raise ConnectionError(result)

--- a/lib/agent0/bin/checkpoint_bot.py
+++ b/lib/agent0/bin/checkpoint_bot.py
@@ -19,7 +19,7 @@ from ethpy.base import (
     smart_contract_read,
     smart_contract_transact,
 )
-from ethpy.hyperdrive import fetch_hyperdrive_address_from_uri, get_hyperdrive_config
+from ethpy.hyperdrive import fetch_hyperdrive_address_from_uri, get_hyperdrive_pool_config
 from fixedpointmath import FixedPoint
 from web3.contract.contract import Contract
 
@@ -86,7 +86,7 @@ def main() -> None:
     # Run the checkpoint bot. This bot will attempt to mint a new checkpoint
     # every checkpoint after a waiting period. It will poll very infrequently
     # to reduce the probability of needing to mint a checkpoint.
-    config = get_hyperdrive_config(hyperdrive_contract)
+    config = get_hyperdrive_pool_config(hyperdrive_contract)
     checkpoint_duration = config["checkpointDuration"]
     while True:
         # Get the latest block time and check to see if a new checkpoint should

--- a/lib/chainsync/chainsync/analysis/data_to_analysis.py
+++ b/lib/chainsync/chainsync/analysis/data_to_analysis.py
@@ -127,7 +127,7 @@ def data_to_analysis(
         pool_info["shareReserves"],
         pool_info["bondReserves"],
         pool_config["initialSharePrice"],
-        pool_config["timeStretch"],  # inverted from solidity
+        pool_config["timeStretch"],
     )
 
     # Calculate fixed rate

--- a/lib/chainsync/chainsync/analysis/data_to_analysis.py
+++ b/lib/chainsync/chainsync/analysis/data_to_analysis.py
@@ -127,7 +127,7 @@ def data_to_analysis(
         pool_info["shareReserves"],
         pool_info["bondReserves"],
         pool_config["initialSharePrice"],
-        pool_config["invTimeStretch"],
+        pool_config["timeStretch"],  # inverted from solidity
     )
 
     # Calculate fixed rate

--- a/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
@@ -9,6 +9,7 @@ from ethpy.hyperdrive import (
     get_hyperdrive_pool_config,
     get_hyperdrive_pool_info,
     process_hyperdrive_pool_config,
+    process_hyperdrive_pool_info,
 )
 from sqlalchemy.orm import Session
 from web3 import Web3
@@ -66,7 +67,14 @@ def data_chain_to_db(
     pool_info_dict = None
     for _ in range(_RETRY_COUNT):
         try:
-            pool_info_dict = get_hyperdrive_pool_info(web3, hyperdrive_contract, block_number)
+            position_duration = int(get_hyperdrive_pool_config(hyperdrive_contract)["positionDuration"])
+            pool_info_dict = process_hyperdrive_pool_info(
+                get_hyperdrive_pool_info(hyperdrive_contract, block_number),
+                web3,
+                hyperdrive_contract,
+                position_duration,
+                block_number,
+            )
             break
         except ValueError:
             logging.warning("Error in get_hyperdrive_pool_info, retrying")

--- a/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
@@ -45,7 +45,12 @@ def init_data_chain_to_db(
     pool_config_dict = None
     for _ in range(_RETRY_COUNT):
         try:
-            pool_config_dict = process_hyperdrive_pool_config(get_hyperdrive_pool_config(hyperdrive_contract))
+            # TODO: Use the hyperdrive API here
+            pool_config_dict = convert_pool_config(
+                process_hyperdrive_pool_config(
+                    get_hyperdrive_pool_config(hyperdrive_contract), hyperdrive_contract.address
+                )
+            )
             break
         except ValueError:
             logging.warning("Error in getting pool config, retrying")
@@ -53,7 +58,7 @@ def init_data_chain_to_db(
             continue
     if pool_config_dict is None:
         raise ValueError("Error in getting pool config")
-    add_pool_config(convert_pool_config(pool_config_dict), session)
+    add_pool_config(pool_config_dict, session)
 
 
 def data_chain_to_db(

--- a/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
@@ -4,7 +4,12 @@ import time
 
 from eth_typing import BlockNumber
 from ethpy.base import fetch_contract_transactions_for_block
-from ethpy.hyperdrive import get_hyperdrive_checkpoint_info, get_hyperdrive_pool_config, get_hyperdrive_pool_info
+from ethpy.hyperdrive import (
+    get_hyperdrive_checkpoint_info,
+    get_hyperdrive_pool_config,
+    get_hyperdrive_pool_info,
+    process_hyperdrive_pool_config,
+)
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.contract.contract import Contract
@@ -38,7 +43,7 @@ def init_data_chain_to_db(
     pool_config_dict = None
     for _ in range(_RETRY_COUNT):
         try:
-            pool_config_dict = get_hyperdrive_pool_config(hyperdrive_contract)
+            pool_config_dict = process_hyperdrive_pool_config(get_hyperdrive_pool_config(hyperdrive_contract))
             break
         except ValueError:
             logging.warning("Error in getting pool config, retrying")

--- a/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
@@ -4,7 +4,7 @@ import time
 
 from eth_typing import BlockNumber
 from ethpy.base import fetch_contract_transactions_for_block
-from ethpy.hyperdrive import get_hyperdrive_checkpoint_info, get_hyperdrive_config, get_hyperdrive_pool_info
+from ethpy.hyperdrive import get_hyperdrive_checkpoint_info, get_hyperdrive_pool_config, get_hyperdrive_pool_info
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.contract.contract import Contract
@@ -38,7 +38,7 @@ def init_data_chain_to_db(
     pool_config_dict = None
     for _ in range(_RETRY_COUNT):
         try:
-            pool_config_dict = get_hyperdrive_config(hyperdrive_contract)
+            pool_config_dict = get_hyperdrive_pool_config(hyperdrive_contract)
             break
         except ValueError:
             logging.warning("Error in getting pool config, retrying")

--- a/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
@@ -5,9 +5,10 @@ import time
 from eth_typing import BlockNumber
 from ethpy.base import fetch_contract_transactions_for_block
 from ethpy.hyperdrive import (
-    get_hyperdrive_checkpoint_info,
+    get_hyperdrive_checkpoint,
     get_hyperdrive_pool_config,
     get_hyperdrive_pool_info,
+    process_hyperdrive_checkpoint,
     process_hyperdrive_pool_config,
     process_hyperdrive_pool_info,
 )
@@ -89,7 +90,9 @@ def data_chain_to_db(
     checkpoint_info_dict = None
     for _ in range(_RETRY_COUNT):
         try:
-            checkpoint_info_dict = get_hyperdrive_checkpoint_info(web3, hyperdrive_contract, block_number)
+            checkpoint_info_dict = process_hyperdrive_checkpoint(
+                get_hyperdrive_checkpoint(hyperdrive_contract, block_number), web3, block_number
+            )
             break
         except ValueError:
             logging.warning("Error in get_hyperdrive_checkpoint_info, retrying")

--- a/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
@@ -63,18 +63,17 @@ def data_chain_to_db(
     block_number: BlockNumber,
     session: Session,
 ) -> None:
-    """Function to query and insert data to dashboard"""
+    """Function to query and insert data to dashboard."""
     # Query and add block_pool_info
     pool_info_dict = None
     for _ in range(_RETRY_COUNT):
         try:
-            position_duration = int(get_hyperdrive_pool_config(hyperdrive_contract)["positionDuration"])
             pool_info_dict = process_hyperdrive_pool_info(
-                get_hyperdrive_pool_info(hyperdrive_contract, block_number),
-                web3,
-                hyperdrive_contract,
-                position_duration,
-                block_number,
+                pool_info=get_hyperdrive_pool_info(hyperdrive_contract, block_number),
+                web3=web3,
+                hyperdrive_contract=hyperdrive_contract,
+                position_duration=int(get_hyperdrive_pool_config(hyperdrive_contract)["positionDuration"]),
+                block_number=block_number,
             )
             break
         except ValueError:

--- a/lib/chainsync/chainsync/db/hyperdrive/convert_data.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/convert_data.py
@@ -233,7 +233,7 @@ def convert_pool_config(pool_config_dict: dict[str, Any]) -> PoolConfig:
     Arguments
     ---------
     pool_config_dict: dict[str, Any]
-        The dictionary returned from hyperdrive_instance.get_hyperdrive_config
+        A dicitonary containing the required pool_config keys.
 
     Returns
     -------

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -5,11 +5,12 @@ from .assets import AssetIdPrefix, decode_asset_id, encode_asset_id
 from .errors import HyperdriveErrors, lookup_hyperdrive_error_selector
 from .get_web3_and_hyperdrive_contracts import get_web3_and_hyperdrive_contracts
 from .interface import (
-    get_hyperdrive_checkpoint_info,
+    get_hyperdrive_checkpoint,
     get_hyperdrive_market,
     get_hyperdrive_pool_config,
     get_hyperdrive_pool_info,
     parse_logs,
+    process_hyperdrive_checkpoint,
     process_hyperdrive_pool_config,
     process_hyperdrive_pool_info,
 )

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -9,3 +9,4 @@ from .interface import (
     get_hyperdrive_market,
     get_hyperdrive_pool_info,
 )
+from .receipt_breakdown import ReceiptBreakdown

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -1,5 +1,6 @@
 """Interfaces for bots and hyperdrive smart contracts."""
 from .addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
+from .api import HyperdriveInterface
 from .assets import AssetIdPrefix, decode_asset_id, encode_asset_id
 from .errors import HyperdriveErrors, lookup_hyperdrive_error_selector
 from .get_web3_and_hyperdrive_contracts import get_web3_and_hyperdrive_contracts

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -11,5 +11,6 @@ from .interface import (
     get_hyperdrive_pool_info,
     parse_logs,
     process_hyperdrive_pool_config,
+    process_hyperdrive_pool_info,
 )
 from .receipt_breakdown import ReceiptBreakdown

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -8,5 +8,6 @@ from .interface import (
     get_hyperdrive_config,
     get_hyperdrive_market,
     get_hyperdrive_pool_info,
+    parse_logs,
 )
 from .receipt_breakdown import ReceiptBreakdown

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -6,8 +6,8 @@ from .errors import HyperdriveErrors, lookup_hyperdrive_error_selector
 from .get_web3_and_hyperdrive_contracts import get_web3_and_hyperdrive_contracts
 from .interface import (
     get_hyperdrive_checkpoint_info,
-    get_hyperdrive_config,
     get_hyperdrive_market,
+    get_hyperdrive_pool_config,
     get_hyperdrive_pool_info,
     parse_logs,
 )

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -10,5 +10,6 @@ from .interface import (
     get_hyperdrive_pool_config,
     get_hyperdrive_pool_info,
     parse_logs,
+    process_hyperdrive_pool_config,
 )
 from .receipt_breakdown import ReceiptBreakdown

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -1,6 +1,7 @@
 """High-level interface for the Hyperdrive market"""
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 import eth_utils
@@ -93,7 +94,7 @@ class HyperdriveInterface:
             self.config, addresses_arg
         )
         self._contract_pool_config = get_hyperdrive_pool_config(self.hyperdrive_contract)
-        self.pool_config = process_hyperdrive_pool_config(self._contract_pool_config)
+        self.pool_config = process_hyperdrive_pool_config(copy.deepcopy(self._contract_pool_config))
         self.last_state_block = self.web3.eth.get_block("latest")
         self._contract_pool_info: dict[str, Any] = {}
         self._pool_info: dict[str, Any] = {}
@@ -147,21 +148,21 @@ class HyperdriveInterface:
             The current spot price.
         """
         pool_config_str = PoolConfig(
-            base_token=str(self.pool_config["base_token"]),
-            initial_share_price=str(self.pool_config["initial_share_price"]),
-            minimum_share_reserves=str(self.pool_config["minimum_share_reserves"]),
-            position_duration=str(self.pool_config["position_duration"]),
-            checkpoint_duration=str(self.pool_config["checkpoint_duration"]),
-            time_stretch=str(self.pool_config["time_stretch"]),
-            governance=str(self.pool_config["governance"]),
-            fee_collector=str(self.pool_config["fee_collector"]),
+            base_token=str(self._contract_pool_config["base_token"]),
+            initial_share_price=str(self._contract_pool_config["initial_share_price"]),
+            minimum_share_reserves=str(self._contract_pool_config["minimum_share_reserves"]),
+            position_duration=str(self._contract_pool_config["position_duration"]),
+            checkpoint_duration=str(self._contract_pool_config["checkpoint_duration"]),
+            time_stretch=str(self._contract_pool_config["time_stretch"]),
+            governance=str(self._contract_pool_config["governance"]),
+            fee_collector=str(self._contract_pool_config["fee_collector"]),
             fees=Fees(
-                curve=str(self.pool_config["fees"]["curve"]),
-                flat=str(self.pool_config["fees"]["flat"]),
-                governance=str(self.pool_config["fees"]["governance"]),
+                curve=str(self._contract_pool_config["fees"]["curve"]),
+                flat=str(self._contract_pool_config["fees"]["flat"]),
+                governance=str(self._contract_pool_config["fees"]["governance"]),
             ),
-            oracle_size=str(self.pool_config["oracle_size"]),
-            update_gap=str(self.pool_config["update_gap"]),
+            oracle_size=str(self._contract_pool_config["oracle_size"]),
+            update_gap=str(self._contract_pool_config["update_gap"]),
         )
         pool_info_str = PoolInfo(
             share_reserves=str(self.pool_info["share_reserves"]),
@@ -192,7 +193,7 @@ class HyperdriveInterface:
             self,
             "_pool_info",
             process_hyperdrive_pool_info(
-                self._contract_pool_info,
+                copy.deepcopy(self._contract_pool_info),
                 self.web3,
                 self.hyperdrive_contract,
                 self.pool_config["positionDuration"],

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -312,7 +312,7 @@ class HyperdriveInterface:
         """
         agent_checksum_address = Web3.to_checksum_address(agent.address)
         as_underlying = True
-        max_deposit = eth_utils.currency.MAX_WEI
+        max_deposit = int(eth_utils.currency.MAX_WEI)
         fn_args = (trade_amount.scaled_value, max_deposit, agent_checksum_address, as_underlying)
         if slippage_tolerance:
             preview_result = smart_contract_preview_transaction(
@@ -360,7 +360,7 @@ class HyperdriveInterface:
         as_underlying = True
         fn_args = (
             int(maturity_time),
-            trade_amount,
+            trade_amount.scaled_value,
             min_output,
             agent_checksum_address,
             as_underlying,
@@ -372,7 +372,7 @@ class HyperdriveInterface:
             min_output = (
                 FixedPoint(scaled_value=preview_result["value"]) * (FixedPoint(1) - slippage_tolerance)
             ).scaled_value
-            fn_args = (int(maturity_time), trade_amount, min_output, agent_checksum_address, as_underlying)
+            fn_args = (int(maturity_time), trade_amount.scaled_value, min_output, agent_checksum_address, as_underlying)
         tx_receipt = await async_smart_contract_transact(
             self.web3, self.hyperdrive_contract, agent, "closeShort", *fn_args
         )
@@ -406,7 +406,13 @@ class HyperdriveInterface:
         """
         agent_checksum_address = Web3.to_checksum_address(agent.address)
         as_underlying = True
-        fn_args = (trade_amount, min_apr, max_apr, agent_checksum_address, as_underlying)
+        fn_args = (
+            trade_amount.scaled_value,
+            min_apr.scaled_value,
+            max_apr.scaled_value,
+            agent_checksum_address,
+            as_underlying,
+        )
         tx_receipt = await async_smart_contract_transact(
             self.web3, self.hyperdrive_contract, agent, "addLiquidity", *fn_args
         )
@@ -435,7 +441,7 @@ class HyperdriveInterface:
         agent_checksum_address = Web3.to_checksum_address(agent.address)
         min_output = 0
         as_underlying = True
-        fn_args = (trade_amount, min_output, agent_checksum_address, as_underlying)
+        fn_args = (trade_amount.scaled_value, min_output, agent_checksum_address, as_underlying)
         tx_receipt = await async_smart_contract_transact(
             self.web3, self.hyperdrive_contract, agent, "removeLiquidity", *fn_args
         )

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -213,7 +213,7 @@ class Hyperdrive:
         maturity_time: FixedPoint,
         slippage_tolerance: FixedPoint | None = None,
     ) -> ReceiptBreakdown:
-        """Contract call to open a short position.
+        """Contract call to close a short position.
 
         Arguments
         ---------
@@ -255,6 +255,40 @@ class Hyperdrive:
             self.web3, self.hyperdrive_contract, agent, "closeShort", *fn_args
         )
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "closeShort")
+        return trade_result
+
+    async def async_add_liquidity(
+        self,
+        agent: LocalAccount,
+        trade_amount: FixedPoint,
+        min_apr: FixedPoint,
+        max_apr: FixedPoint,
+    ) -> ReceiptBreakdown:
+        """Contract call to add liquidity to the Hyperdrive pool.
+
+        Arguments
+        ---------
+        agent: LocalAccount
+            The account for the agent that is executing and signing the trade transaction.
+        trade_amount: FixedPoint
+            The size of the position, in base.
+        min_apr: FixedPoint
+            The minimum allowable APR after liquidity is added.
+        max_apr: FixedPoint
+            The maximum allowable APR after liquidity is added.
+
+        Returns
+        -------
+        ReceiptBreakdown
+            A dataclass containing the absolute values for token quantities changed
+        """
+        agent_checksum_address = Web3.to_checksum_address(agent.address)
+        as_underlying = True
+        fn_args = (trade_amount, min_apr, max_apr, agent_checksum_address, as_underlying)
+        tx_receipt = await async_smart_contract_transact(
+            self.web3, self.hyperdrive_contract, agent, "addLiquidity", *fn_args
+        )
+        trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "addLiquidity")
         return trade_result
 
     # FIXME: TODO: other async trades

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -24,7 +24,7 @@ from .interface import get_hyperdrive_config, get_hyperdrive_pool_info, parse_lo
 from .receipt_breakdown import ReceiptBreakdown
 
 
-class Hyperdrive:
+class HyperdriveInterface:
     """End-point api for interfacing with Hyperdrive"""
 
     def __init__(
@@ -62,11 +62,6 @@ class Hyperdrive:
                 get_hyperdrive_pool_info(self.web3, self.hyperdrive_contract, self.current_block_number),
             )
         return self._pool_info
-
-    @_pool_info.setter
-    def _pool_info(self, value: Any) -> None:
-        """Not allowed to set the pool info manually"""
-        raise ValueError("_pool_info is immutable")
 
     @property
     def current_block(self) -> BlockData:
@@ -460,6 +455,8 @@ class Hyperdrive:
         FixedPoint
             The maximum long as a FixedPoint representation of a Solidity uint256 value.
         """
+        # pylint: disable=no-member
+        # TODO: automate acquision of current_exposure inside of pyperdrive
         pool_config_str = PoolConfig(
             base_token=str(self.pool_config["base_token"]),
             initial_share_price=str(self.pool_config["initial_share_price"]),
@@ -492,7 +489,7 @@ class Hyperdrive:
             lp_share_price=str(self.pool_info["lp_share_price"]),
             long_exposure=str(self.pool_info["long_exposure"]),
         )
-        max_long = pyperdrive.get_max_long(pool_config_str, pool_info_str, str(budget) checkpoint_exposure="0")
+        max_long = pyperdrive.get_max_long(pool_config_str, pool_info_str, str(budget), checkpoint_exposure="0")
         return FixedPoint(max_long)
 
     def get_max_short(self, budget: FixedPoint) -> FixedPoint:
@@ -508,6 +505,7 @@ class Hyperdrive:
         FixedPoint
             The maximum long as a FixedPoint representation of a Solidity uint256 value.
         """
+        # pylint: disable=no-member
         pool_config_str = PoolConfig(
             base_token=str(self.pool_config["base_token"]),
             initial_share_price=str(self.pool_config["initial_share_price"]),

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -1,8 +1,6 @@
 """High-level interface for the Hyperdrive market"""
 from __future__ import annotations
 
-from typing import Any
-
 import eth_utils
 import pyperdrive
 from eth_account.signers.local import LocalAccount
@@ -21,7 +19,7 @@ from web3 import Web3
 from web3.types import BlockData, Timestamp
 
 from .get_web3_and_hyperdrive_contracts import get_web3_and_hyperdrive_contracts
-from .interface import get_hyperdrive_config, get_hyperdrive_pool_info, get_hyperdrive_checkpoint_info, parse_logs
+from .interface import get_hyperdrive_checkpoint_info, get_hyperdrive_config, get_hyperdrive_pool_info, parse_logs
 from .receipt_breakdown import ReceiptBreakdown
 
 
@@ -65,7 +63,9 @@ class HyperdriveInterface:
         )
         self.pool_config = get_hyperdrive_config(self.hyperdrive_contract)
         self._pool_info = get_hyperdrive_pool_info(self.web3, self.hyperdrive_contract, self.current_block_number)
-        self._latest_checkpoint = get_hyperdrive_checkpoint_info(self.web3, self.hyperdrive_contract, self.current_block_number)
+        self._latest_checkpoint = get_hyperdrive_checkpoint_info(
+            self.web3, self.hyperdrive_contract, self.current_block_number
+        )
         self.last_state_block = self.web3.eth.get_block("latest")
 
     @property
@@ -79,9 +79,9 @@ class HyperdriveInterface:
                 get_hyperdrive_pool_info(self.web3, self.hyperdrive_contract, self.current_block_number),
             )
         return self._pool_info
-    
-    @property
-    def latest_checkpoint(self):
+
+    # @property
+    # def latest_checkpoint(self):
 
     @property
     def current_block(self) -> BlockData:
@@ -145,7 +145,7 @@ class HyperdriveInterface:
             lp_share_price=str(self.pool_info["lp_share_price"]),
             long_exposure=str(self.pool_info["long_exposure"]),
         )
-        spot_price = pyperdrive.get_spot_price(pool_config_str, pool_info_str)
+        spot_price = pyperdrive.get_spot_price(pool_config_str, pool_info_str)  # pylint: disable=no-member
         return FixedPoint(spot_price)
 
     async def async_open_long(

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -476,7 +476,7 @@ class HyperdriveInterface:
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "redeemWithdrawalShares")
         return trade_result
 
-    def balance_of(self, agent: LocalAccount) -> tuple[FixedPoint, FixedPoint]:
+    def get_eth_base_balances(self, agent: LocalAccount) -> tuple[FixedPoint, FixedPoint]:
         """Get the agent's balance on the Hyperdrive & base contracts.
 
         Arguments
@@ -488,7 +488,6 @@ class HyperdriveInterface:
         -------
         tuple[FixedPoint]
             A tuple containing the [agent_eth_balance, agent_base_balance]
-
         """
         agent_checksum_address = Web3.to_checksum_address(agent.address)
         agent_eth_balance = get_account_balance(self.web3, agent_checksum_address)

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -13,7 +13,7 @@ from ethpy.base import (
 )
 from fixedpointmath import FixedPoint
 from web3 import Web3
-from web3.types import BlockData
+from web3.types import BlockData, Timestamp
 
 from .get_web3_and_hyperdrive_contracts import get_web3_and_hyperdrive_contracts
 from .interface import get_hyperdrive_config, get_hyperdrive_pool_info, parse_logs
@@ -56,16 +56,24 @@ class Hyperdrive:
 
     @property
     def current_block(self) -> BlockData:
-        """The current block number, which must be set with a setter method"""
+        """The current block number"""
         return self.web3.eth.get_block("latest")
 
     @property
     def current_block_number(self) -> BlockNumber:
-        """The current block number, which must be set with a setter method"""
+        """The current block number."""
         current_block_number = self.current_block.get("number", None)
         if current_block_number is None:
             raise AssertionError("The current block has no number")
         return current_block_number
+
+    @property
+    def current_block_time(self) -> Timestamp:
+        """The current block timestamp."""
+        current_block_timestamp = self.current_block.get("timestamp", None)
+        if current_block_timestamp is None:
+            raise AssertionError("current_block_timestamp can not be None")
+        return current_block_timestamp
 
     # FIXME:
     # @property

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -291,6 +291,35 @@ class Hyperdrive:
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "addLiquidity")
         return trade_result
 
+    async def async_remove_liquidity(
+        self,
+        agent: LocalAccount,
+        trade_amount: FixedPoint,
+    ) -> ReceiptBreakdown:
+        """Contract call to remove liquidity from the Hyperdrive pool.
+
+        Arguments
+        ---------
+        agent: LocalAccount
+            The account for the agent that is executing and signing the trade transaction.
+        trade_amount: FixedPoint
+            The size of the position, in base.
+
+        Returns
+        -------
+        ReceiptBreakdown
+            A dataclass containing the absolute values for token quantities changed
+        """
+        agent_checksum_address = Web3.to_checksum_address(agent.address)
+        min_output = 0
+        as_underlying = True
+        fn_args = (trade_amount, min_output, agent_checksum_address, as_underlying)
+        tx_receipt = await async_smart_contract_transact(
+            self.web3, self.hyperdrive_contract, agent, "removeLiquidity", *fn_args
+        )
+        trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "removeLiquidity")
+        return trade_result
+
     # FIXME: TODO: other async trades
 
     # FIXME: TODO:

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -23,10 +23,11 @@ from web3.types import BlockData, Timestamp
 
 from .get_web3_and_hyperdrive_contracts import get_web3_and_hyperdrive_contracts
 from .interface import (
-    get_hyperdrive_checkpoint_info,
+    get_hyperdrive_checkpoint,
     get_hyperdrive_pool_config,
     get_hyperdrive_pool_info,
     parse_logs,
+    process_hyperdrive_checkpoint,
     process_hyperdrive_pool_config,
     process_hyperdrive_pool_info,
 )
@@ -98,6 +99,7 @@ class HyperdriveInterface:
         self.last_state_block = self.web3.eth.get_block("latest")
         self._contract_pool_info: dict[str, Any] = {}
         self._pool_info: dict[str, Any] = {}
+        self._contract_latest_checkpoint: dict[str, int] = {}
         self._latest_checkpoint: dict[str, Any] = {}
         self.update_pool_info_and_checkpoint()  # fill these in initially
 
@@ -202,8 +204,15 @@ class HyperdriveInterface:
         )
         setattr(
             self,
+            "_contract_latest_checkpoint",
+            get_hyperdrive_checkpoint(self.hyperdrive_contract, self.current_block_number),
+        )
+        setattr(
+            self,
             "_latest_checkpoint",
-            get_hyperdrive_checkpoint_info(self.web3, self.hyperdrive_contract, self.current_block_number),
+            process_hyperdrive_checkpoint(
+                copy.deepcopy(self._contract_latest_checkpoint), self.web3, self.current_block_number
+            ),
         )
 
     async def async_open_long(

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -1,0 +1,94 @@
+"""High-level interface for the Hyperdrive market"""
+from __future__ import annotations
+
+from eth_account.signers.local import LocalAccount
+from eth_typing import BlockNumber
+from ethpy.base import async_smart_contract_transact, smart_contract_preview_transaction
+from fixedpointmath import FixedPoint
+from web3 import Web3
+from web3.contract.contract import Contract
+from web3.types import BlockData
+
+from .interface import get_hyperdrive_config, get_hyperdrive_pool_info, parse_logs
+from .receipt_breakdown import ReceiptBreakdown
+
+
+class Hyperdrive:
+    """End-point api for interfacing with Hyperdrive"""
+
+    def __init__(self, web3: Web3, hyperdrive_contract: Contract, base_contract: Contract):
+        self.web3 = web3
+        self.hyperdrive_contract = hyperdrive_contract
+        self.base_contract = base_contract
+
+    @property
+    def pool_config(self):
+        """Returns the pool initialization config"""
+        return get_hyperdrive_config(self.hyperdrive_contract)
+
+    @property
+    def pool_info(self):
+        """Returns the current pool state info"""
+        return get_hyperdrive_pool_info(self.web3, self.hyperdrive_contract, self.current_block_number)
+
+    @property
+    def current_block(self) -> BlockData:
+        """The current block number, which must be set with a setter method"""
+        return self.web3.eth.get_block("latest")
+
+    @property
+    def current_block_number(self) -> BlockNumber:
+        """The current block number, which must be set with a setter method"""
+        current_block_number = self.current_block.get("number", None)
+        if current_block_number is None:
+            raise AssertionError("The current block has no number")
+        return current_block_number
+
+    async def async_open_long(
+        self, trade_amount: int, agent: LocalAccount, slippage_tolerance: FixedPoint | None = None
+    ) -> ReceiptBreakdown:
+        """Contract call to open a long position.
+
+        Arguments
+        ---------
+        trade_amount: int
+            The size of the position, in base.
+        agent: LocalAccount
+            The account for the agent that is executing and signing the trade transaction.
+        slippage_tolerance: FixedPoint | None
+            Amount of slippage allowed from the trade.
+            If None, then execute the trade regardless of the slippage.
+            If not None, then the trade will not execute unless the slippage is below this value.
+
+        Returns
+        -------
+        ReceiptBreakdown
+            A dataclass containing the maturity time and the absolute values for token quantities changed
+        """
+        agent_checksum_address = Web3.to_checksum_address(agent.address)
+        min_output = 0
+        as_underlying = True
+        fn_args = (trade_amount, min_output, agent_checksum_address, as_underlying)
+        if slippage_tolerance is not None:
+            preview_result = smart_contract_preview_transaction(
+                self.hyperdrive_contract, agent_checksum_address, "openLong", *fn_args
+            )
+            min_output = (
+                FixedPoint(scaled_value=preview_result["bondProceeds"]) * (FixedPoint(1) - slippage_tolerance)
+            ).scaled_value
+            fn_args = (trade_amount, min_output, agent_checksum_address, as_underlying)
+        tx_receipt = await async_smart_contract_transact(
+            self.web3, self.hyperdrive_contract, agent, "openLong", *fn_args
+        )
+        trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "openLong")
+        return trade_result
+
+    # FIXME: TODO: other async trades
+
+    # FIXME: TODO:
+    # def get_max_long(budget):
+    #     pyperdrive.get_max_long(...)
+
+    # FIXME: TODO:
+    # def get_max_short(budget):
+    #     pyperdrive.get_max_short(...)

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -233,7 +233,7 @@ class HyperdriveInterface:
         self,
         agent: LocalAccount,
         trade_amount: FixedPoint,
-        maturity_time: FixedPoint,
+        maturity_time: int,
         slippage_tolerance: FixedPoint | None = None,
     ) -> ReceiptBreakdown:
         """Contract call to close a long position.
@@ -244,7 +244,7 @@ class HyperdriveInterface:
             The account for the agent that is executing and signing the trade transaction.
         trade_amount: FixedPoint
             The size of the position, in base.
-        maturity_time: FixedPoint
+        maturity_time: int
             The token maturity time in seconds.
         slippage_tolerance: FixedPoint | None
             Amount of slippage allowed from the trade.
@@ -260,7 +260,7 @@ class HyperdriveInterface:
         min_output = 0
         as_underlying = True
         fn_args = (
-            int(maturity_time),
+            maturity_time,
             trade_amount.scaled_value,
             min_output,
             agent_checksum_address,
@@ -274,7 +274,7 @@ class HyperdriveInterface:
                 FixedPoint(scaled_value=preview_result["value"]) * (FixedPoint(1) - slippage_tolerance)
             ).scaled_value
             fn_args = (
-                int(maturity_time),
+                maturity_time,
                 trade_amount.scaled_value,
                 min_output,
                 agent_checksum_address,
@@ -332,7 +332,7 @@ class HyperdriveInterface:
         self,
         agent: LocalAccount,
         trade_amount: FixedPoint,
-        maturity_time: FixedPoint,
+        maturity_time: int,
         slippage_tolerance: FixedPoint | None = None,
     ) -> ReceiptBreakdown:
         """Contract call to close a short position.
@@ -343,7 +343,7 @@ class HyperdriveInterface:
             The account for the agent that is executing and signing the trade transaction.
         trade_amount: FixedPoint
             The size of the position, in base.
-        maturity_time: FixedPoint
+        maturity_time: int
             The token maturity time in seconds.
         slippage_tolerance: FixedPoint | None
             Amount of slippage allowed from the trade.
@@ -359,7 +359,7 @@ class HyperdriveInterface:
         min_output = 0
         as_underlying = True
         fn_args = (
-            int(maturity_time),
+            maturity_time,
             trade_amount.scaled_value,
             min_output,
             agent_checksum_address,
@@ -372,7 +372,7 @@ class HyperdriveInterface:
             min_output = (
                 FixedPoint(scaled_value=preview_result["value"]) * (FixedPoint(1) - slippage_tolerance)
             ).scaled_value
-            fn_args = (int(maturity_time), trade_amount.scaled_value, min_output, agent_checksum_address, as_underlying)
+            fn_args = (maturity_time, trade_amount.scaled_value, min_output, agent_checksum_address, as_underlying)
         tx_receipt = await async_smart_contract_transact(
             self.web3, self.hyperdrive_contract, agent, "closeShort", *fn_args
         )

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -19,7 +19,13 @@ from web3 import Web3
 from web3.types import BlockData, Timestamp
 
 from .get_web3_and_hyperdrive_contracts import get_web3_and_hyperdrive_contracts
-from .interface import get_hyperdrive_checkpoint_info, get_hyperdrive_config, get_hyperdrive_pool_info, parse_logs
+from .interface import (
+    get_hyperdrive_checkpoint_info,
+    get_hyperdrive_pool_config,
+    get_hyperdrive_pool_info,
+    parse_logs,
+    process_hyperdrive_pool_config,
+)
 from .receipt_breakdown import ReceiptBreakdown
 
 
@@ -80,8 +86,11 @@ class HyperdriveInterface:
         self.web3, self.base_token_contract, self.hyperdrive_contract = get_web3_and_hyperdrive_contracts(
             self.config, addresses_arg
         )
-        self.pool_config = get_hyperdrive_config(self.hyperdrive_contract)
-        self._pool_info = get_hyperdrive_pool_info(self.web3, self.hyperdrive_contract, self.current_block_number)
+        self._contract_pool_config = get_hyperdrive_pool_config(self.hyperdrive_contract)
+        self.pool_config = process_hyperdrive_pool_config(self._contract_pool_config)
+        self._contract_pool_info = get_hyperdrive_pool_info(
+            self.web3, self.hyperdrive_contract, self.current_block_number
+        )
         self._latest_checkpoint = get_hyperdrive_checkpoint_info(
             self.web3, self.hyperdrive_contract, self.current_block_number
         )
@@ -94,10 +103,12 @@ class HyperdriveInterface:
             self.last_state_block = self.current_block
             setattr(
                 self,
-                "_pool_info",
+                "_contract_pool_info",
                 get_hyperdrive_pool_info(self.web3, self.hyperdrive_contract, self.current_block_number),
             )
-        return self._pool_info
+            # TODO: set _pool_info = post-process(self._contract_pool_info)
+            # return self._pool_info
+        return self._contract_pool_info
 
     @property
     def latest_checkpoint(self):

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -34,12 +34,32 @@ class HyperdriveInterface:
         rpc_uri: str | URI | None = None,
         abi_dir: str | None = None,
     ) -> None:
-        """The Hyperdrive API can be initialized with either an EthConfig,
-        or strings corresponding to the required URIs and directories.
+        """The HyperdriveInterface API has multiple valid constructors.
 
-        ## TODO: Write out options for initializing HyperdriveInterface
-            ## or: PR to fix this to happen behind the scenes in EthConfig
-            ## or: Make an issue to fix EthConfig so that it handles all of this optional argument bullshit
+        Different workflows result in different call signatures for initializing this object.
+        You can construct a HyperdriveInterface with an EthConfig object,
+        which takes in URIs that point to the requesite assets:
+
+        .. code-block::
+          eth_config = EthConfig(artifacts_uri, rpc_uri, abi_dir)
+          hyperdrive = HyperdriveInterface(eth_config)
+
+        or you can construct it with the URIs themselves (which requires kwargs):
+
+        .. code-block::
+          hyperdrive = HyperdriveInterface(artifacts=artifacts_uri, rpc_uri=rpc_uri, abi_dir=abi_dir)
+
+        You may also have direct access to the HyperdriveAddresses, instead of a URI for an artifacts server.
+        In this case, you can construct the interface using those addresses and the remaining URIs
+        (also requiring kwargs):
+
+        .. code-block::
+          # acquire addresses from URI, or via some other mechanism
+          addresses = ethpy.hyperdrive.addresses.fetch_hyperdrive_address_from_uri(artifacts_uri)
+          # initialize hyperdrive
+          hyperdrive = HyperdriveInterface(artifacts=addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
+
+
         ## TODO: Change pyperdrive interface to take str OR python FixedPoint objs; use FixedPoint here.
         """
         if all([eth_config is None, artifacts is None, rpc_uri is None, abi_dir is None]):
@@ -416,6 +436,7 @@ class HyperdriveInterface:
         """Contract call to redeem withdraw shares from Hyperdrive pool.
 
         This should be done after closing liquidity.
+
         .. note::
             This is not guaranteed to redeem all shares.  The pool will try to redeem as
             many as possible, up to the withdrawPool.readyToRedeem limit, without reverting.

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -33,12 +33,16 @@ from .interface import (
 )
 from .receipt_breakdown import ReceiptBreakdown
 
-
 # known issue where class properties aren't recognized as subscriptable
 # https://github.com/pylint-dev/pylint/issues/5699
 # pylint: disable=unsubscriptable-object
+
+
 class HyperdriveInterface:
     """End-point api for interfacing with Hyperdrive."""
+
+    # we expect to have many instance attributes since this is a large API
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(
         self,

--- a/lib/ethpy/ethpy/hyperdrive/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api_test.py
@@ -26,7 +26,6 @@ class TestHyperdriveInterface:
         uri: URI | None = cast(HTTPProvider, local_hyperdrive_chain.web3.provider).endpoint_uri
         rpc_uri = uri if uri else URI("http://localhost:8545")
         abi_dir = "./packages/hyperdrive/src/abis"
-        deploy_account: LocalAccount = local_hyperdrive_chain.deploy_account
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
         hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
         pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
@@ -43,8 +42,25 @@ class TestHyperdriveInterface:
         uri: URI | None = cast(HTTPProvider, local_hyperdrive_chain.web3.provider).endpoint_uri
         rpc_uri = uri if uri else URI("http://localhost:8545")
         abi_dir = "./packages/hyperdrive/src/abis"
-        deploy_account: LocalAccount = local_hyperdrive_chain.deploy_account
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
         hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
         pool_info = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolInfo")
         assert pool_info == hyperdrive._contract_pool_info  # pylint: disable=protected-access
+
+    def test_checkpoint(
+        self,
+        local_hyperdrive_chain: LocalHyperdriveChain,
+    ):
+        """Checks that the Hyperdrive checkpoint matches what is returned from the smart contract.
+
+        All arguments are fixtures.
+        """
+        uri: URI | None = cast(HTTPProvider, local_hyperdrive_chain.web3.provider).endpoint_uri
+        rpc_uri = uri if uri else URI("http://localhost:8545")
+        abi_dir = "./packages/hyperdrive/src/abis"
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
+        hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
+        checkpoint = smart_contract_read(
+            hyperdrive.hyperdrive_contract, "getCheckpoint", hyperdrive.current_block_number
+        )
+        assert checkpoint == hyperdrive._contract_latest_checkpoint  # pylint: disable=protected-access

--- a/lib/ethpy/ethpy/hyperdrive/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api_test.py
@@ -32,7 +32,7 @@ class TestHyperdriveInterface:
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
         hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
         pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
-        assert pool_config == hyperdrive._contract_pool_config
+        assert pool_config == hyperdrive._contract_pool_config  # pylint: disable=protected-access
 
     def test_pool_info(
         self,
@@ -49,4 +49,4 @@ class TestHyperdriveInterface:
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
         hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
         pool_info = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolInfo")
-        assert pool_info == hyperdrive._contract_pool_info
+        assert pool_info == hyperdrive._contract_pool_info  # pylint: disable=protected-access

--- a/lib/ethpy/ethpy/hyperdrive/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api_test.py
@@ -3,22 +3,19 @@ from __future__ import annotations
 
 from typing import cast
 
-from eth_account.signers.local import LocalAccount
 from eth_typing import URI
 from ethpy.base.transactions import smart_contract_read
 from ethpy.hyperdrive.addresses import HyperdriveAddresses
 from ethpy.hyperdrive.api import HyperdriveInterface
 from ethpy.test_fixtures.local_chain import LocalHyperdriveChain
+from fixedpointmath import FixedPoint
 from web3 import HTTPProvider
 
 
 class TestHyperdriveInterface:
     """Tests for the HyperdriveInterface api class."""
 
-    def test_pool_config(
-        self,
-        local_hyperdrive_chain: LocalHyperdriveChain,
-    ):
+    def test_pool_config(self, local_hyperdrive_chain: LocalHyperdriveChain):
         """Checks that the Hyperdrive pool_config matches what is returned from the smart contract.
 
         All arguments are fixtures.
@@ -31,10 +28,7 @@ class TestHyperdriveInterface:
         pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
         assert pool_config == hyperdrive._contract_pool_config  # pylint: disable=protected-access
 
-    def test_pool_info(
-        self,
-        local_hyperdrive_chain: LocalHyperdriveChain,
-    ):
+    def test_pool_info(self, local_hyperdrive_chain: LocalHyperdriveChain):
         """Checks that the Hyperdrive pool_info matches what is returned from the smart contract.
 
         All arguments are fixtures.
@@ -47,10 +41,7 @@ class TestHyperdriveInterface:
         pool_info = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolInfo")
         assert pool_info == hyperdrive._contract_pool_info  # pylint: disable=protected-access
 
-    def test_checkpoint(
-        self,
-        local_hyperdrive_chain: LocalHyperdriveChain,
-    ):
+    def test_checkpoint(self, local_hyperdrive_chain: LocalHyperdriveChain):
         """Checks that the Hyperdrive checkpoint matches what is returned from the smart contract.
 
         All arguments are fixtures.
@@ -64,3 +55,25 @@ class TestHyperdriveInterface:
             hyperdrive.hyperdrive_contract, "getCheckpoint", hyperdrive.current_block_number
         )
         assert checkpoint == hyperdrive._contract_latest_checkpoint  # pylint: disable=protected-access
+
+    def test_misc(self, local_hyperdrive_chain: LocalHyperdriveChain):
+        """Placeholder for additional tests.
+
+        These are only verifying that the attributes exist and functions can be called.
+        All arguments are fixtures.
+        """
+        uri: URI | None = cast(HTTPProvider, local_hyperdrive_chain.web3.provider).endpoint_uri
+        rpc_uri = uri if uri else URI("http://localhost:8545")
+        abi_dir = "./packages/hyperdrive/src/abis"
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
+        hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
+        _ = hyperdrive.pool_config
+        _ = hyperdrive.pool_info
+        _ = hyperdrive.latest_checkpoint
+        _ = hyperdrive.current_block
+        _ = hyperdrive.current_block_number
+        _ = hyperdrive.current_block_time
+        _ = hyperdrive.spot_price
+        _ = hyperdrive.get_max_long(FixedPoint(1000))
+        _ = hyperdrive.get_max_short(FixedPoint(1000))
+        # TODO: need an agent address to mock up trades

--- a/lib/ethpy/ethpy/hyperdrive/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api_test.py
@@ -10,24 +10,43 @@ from ethpy.base.transactions import smart_contract_read
 from ethpy.hyperdrive.addresses import HyperdriveAddresses
 from ethpy.hyperdrive.api import HyperdriveInterface
 from ethpy.test_fixtures.local_chain import LocalHyperdriveChain
+from fixedpointmath import FixedPoint
 from web3 import HTTPProvider
 
 
 class TestHyperdriveInterface:
     """Tests for the HyperdriveInterface api class."""
 
-    def test_hyperdrive_interface(
+    def test_pool_config(
         self,
         local_hyperdrive_chain: LocalHyperdriveChain,
     ):
-        """Runs the entire pipeline and checks the database at the end.
+        """Checks that the Hyperdrive pool_config matches what is returned from the smart contract.
+
         All arguments are fixtures.
         """
         uri: URI | None = cast(HTTPProvider, local_hyperdrive_chain.web3.provider).endpoint_uri
         rpc_uri = uri if uri else URI("http://localhost:8545")
+        abi_dir = "./packages/hyperdrive/src/abis"
         deploy_account: LocalAccount = local_hyperdrive_chain.deploy_account
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
-        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri)  # using default abi dir
-        hyperdrive = HyperdriveInterface(eth_config)
+        hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
         pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
-        assert pool_config == hyperdrive.pool_config
+        assert pool_config == hyperdrive._contract_pool_config
+
+    def test_pool_info(
+        self,
+        local_hyperdrive_chain: LocalHyperdriveChain,
+    ):
+        """Checks that the Hyperdrive pool_info matches what is returned from the smart contract.
+
+        All arguments are fixtures.
+        """
+        uri: URI | None = cast(HTTPProvider, local_hyperdrive_chain.web3.provider).endpoint_uri
+        rpc_uri = uri if uri else URI("http://localhost:8545")
+        abi_dir = "./packages/hyperdrive/src/abis"
+        deploy_account: LocalAccount = local_hyperdrive_chain.deploy_account
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
+        hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
+        pool_info = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolInfo")
+        assert pool_info == hyperdrive._contract_pool_info

--- a/lib/ethpy/ethpy/hyperdrive/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import cast
 
+import pytest
 from eth_typing import URI
 from ethpy.base.transactions import smart_contract_read
 from ethpy.hyperdrive.addresses import HyperdriveAddresses
@@ -12,6 +13,7 @@ from fixedpointmath import FixedPoint
 from web3 import HTTPProvider
 
 
+@pytest.mark.skip(reason="Can't test this until we update the IHyperdrive.json ABI")
 class TestHyperdriveInterface:
     """Tests for the HyperdriveInterface api class."""
 

--- a/lib/ethpy/ethpy/hyperdrive/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api_test.py
@@ -9,7 +9,6 @@ from ethpy import EthConfig
 from ethpy.base.transactions import smart_contract_read
 from ethpy.hyperdrive.addresses import HyperdriveAddresses
 from ethpy.hyperdrive.api import HyperdriveInterface
-from ethpy.test_fixtures import local_chain, local_hyperdrive_chain  # pylint: disable=unused-import, ungrouped-imports
 from ethpy.test_fixtures.local_chain import LocalHyperdriveChain
 from web3 import HTTPProvider
 
@@ -28,7 +27,7 @@ class TestHyperdriveInterface:
         rpc_uri = uri if uri else URI("http://localhost:8545")
         deploy_account: LocalAccount = local_hyperdrive_chain.deploy_account
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
-        eth_config = EthConfig(artifacts_uri="http://localhost:8080", rpc_uri=rpc_uri)  # using default abi dir
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri)  # using default abi dir
         hyperdrive = HyperdriveInterface(eth_config)
         pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
         assert pool_config == hyperdrive.pool_config

--- a/lib/ethpy/ethpy/hyperdrive/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api_test.py
@@ -5,6 +5,7 @@ from typing import cast
 
 import pytest
 from eth_typing import URI
+from ethpy import EthConfig
 from ethpy.base.transactions import smart_contract_read
 from ethpy.hyperdrive.addresses import HyperdriveAddresses
 from ethpy.hyperdrive.api import HyperdriveInterface
@@ -26,7 +27,8 @@ class TestHyperdriveInterface:
         rpc_uri = uri if uri else URI("http://localhost:8545")
         abi_dir = "./packages/hyperdrive/src/abis"
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
-        hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
         pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
         assert pool_config == hyperdrive._contract_pool_config  # pylint: disable=protected-access
 
@@ -39,7 +41,8 @@ class TestHyperdriveInterface:
         rpc_uri = uri if uri else URI("http://localhost:8545")
         abi_dir = "./packages/hyperdrive/src/abis"
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
-        hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
         pool_info = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolInfo")
         assert pool_info == hyperdrive._contract_pool_info  # pylint: disable=protected-access
 
@@ -52,7 +55,8 @@ class TestHyperdriveInterface:
         rpc_uri = uri if uri else URI("http://localhost:8545")
         abi_dir = "./packages/hyperdrive/src/abis"
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
-        hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
         checkpoint = smart_contract_read(
             hyperdrive.hyperdrive_contract, "getCheckpoint", hyperdrive.current_block_number
         )
@@ -68,7 +72,8 @@ class TestHyperdriveInterface:
         rpc_uri = uri if uri else URI("http://localhost:8545")
         abi_dir = "./packages/hyperdrive/src/abis"
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
-        hyperdrive = HyperdriveInterface(artifacts=hyperdrive_contract_addresses, rpc_uri=rpc_uri, abi_dir=abi_dir)
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
         _ = hyperdrive.pool_config
         _ = hyperdrive.pool_info
         _ = hyperdrive.latest_checkpoint

--- a/lib/ethpy/ethpy/hyperdrive/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api_test.py
@@ -1,0 +1,34 @@
+"""Tests for hyperdrive/api.py"""
+from __future__ import annotations
+
+from typing import cast
+
+from eth_account.signers.local import LocalAccount
+from eth_typing import URI
+from ethpy import EthConfig
+from ethpy.base.transactions import smart_contract_read
+from ethpy.hyperdrive.addresses import HyperdriveAddresses
+from ethpy.hyperdrive.api import HyperdriveInterface
+from ethpy.test_fixtures import local_chain, local_hyperdrive_chain  # pylint: disable=unused-import, ungrouped-imports
+from ethpy.test_fixtures.local_chain import LocalHyperdriveChain
+from web3 import HTTPProvider
+
+
+class TestHyperdriveInterface:
+    """Tests for the HyperdriveInterface api class."""
+
+    def test_hyperdrive_interface(
+        self,
+        local_hyperdrive_chain: LocalHyperdriveChain,
+    ):
+        """Runs the entire pipeline and checks the database at the end.
+        All arguments are fixtures.
+        """
+        uri: URI | None = cast(HTTPProvider, local_hyperdrive_chain.web3.provider).endpoint_uri
+        rpc_uri = uri if uri else URI("http://localhost:8545")
+        deploy_account: LocalAccount = local_hyperdrive_chain.deploy_account
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
+        eth_config = EthConfig(artifacts_uri="http://localhost:8080", rpc_uri=rpc_uri)  # using default abi dir
+        hyperdrive = HyperdriveInterface(eth_config)
+        pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
+        assert pool_config == hyperdrive.pool_config

--- a/lib/ethpy/ethpy/hyperdrive/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api_test.py
@@ -5,12 +5,10 @@ from typing import cast
 
 from eth_account.signers.local import LocalAccount
 from eth_typing import URI
-from ethpy import EthConfig
 from ethpy.base.transactions import smart_contract_read
 from ethpy.hyperdrive.addresses import HyperdriveAddresses
 from ethpy.hyperdrive.api import HyperdriveInterface
 from ethpy.test_fixtures.local_chain import LocalHyperdriveChain
-from fixedpointmath import FixedPoint
 from web3 import HTTPProvider
 
 

--- a/lib/ethpy/ethpy/hyperdrive/interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface.py
@@ -87,7 +87,7 @@ def get_hyperdrive_checkpoint_info(
         "timestamp": datetime.fromtimestamp(current_block_timestamp),
         "sharePrice": FixedPoint(scaled_value=checkpoint_data["sharePrice"]),
         "longSharePrice": FixedPoint(scaled_value=checkpoint_data["longSharePrice"]),
-        "shortBaseVolume": FixedPoint(scaled_value=checkpoint_data["shortBaseVolume"]),
+        "longExposure": FixedPoint(scaled_value=checkpoint_data["longExposure"]),
     }
 
 

--- a/lib/ethpy/ethpy/hyperdrive/interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface.py
@@ -173,7 +173,9 @@ def process_hyperdrive_checkpoint(checkpoint: dict[str, int], web3: Web3, block_
     out_checkpoint["timestamp"] = datetime.fromtimestamp(int(current_block_timestamp))
     out_checkpoint["sharePrice"] = FixedPoint(scaled_value=checkpoint["sharePrice"])
     out_checkpoint["longSharePrice"] = FixedPoint(scaled_value=checkpoint["longSharePrice"])
-    out_checkpoint["longExposure"] = FixedPoint(scaled_value=checkpoint["longExposure"])
+    # TODO: Pull this out when you update the hyperdrive abi
+    if "longExposure" in checkpoint:
+        out_checkpoint["longExposure"] = FixedPoint(scaled_value=checkpoint["longExposure"])
     return out_checkpoint
 
 

--- a/lib/ethpy/ethpy/hyperdrive/interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface.py
@@ -178,7 +178,7 @@ def process_hyperdrive_checkpoint(checkpoint: dict[str, int], web3: Web3, block_
 
 
 def get_hyperdrive_market(web3: Web3, hyperdrive_contract: Contract) -> HyperdriveMarket:
-    """Constructs an elfpy HyperdriveMarket from the onchain hyperdrive constract state"""
+    """Constructs an elfpy HyperdriveMarket from the onchain hyperdrive constract state."""
     earliest_block = web3.eth.get_block("earliest")
     current_block = web3.eth.get_block("latest")
     pool_config = process_hyperdrive_pool_config(get_hyperdrive_pool_config(hyperdrive_contract))

--- a/lib/ethpy/ethpy/hyperdrive/interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface.py
@@ -110,7 +110,7 @@ def process_hyperdrive_pool_info(
         This output can be inserted into the Postgres PoolInfo schema.
     """
     # convert values to fixedpoint
-    pool_info: dict[str, Any] = {str(key): FixedPoint(scaled_value=value) for (key, value) in pool_info.items()}
+    pool_info = {str(key): FixedPoint(scaled_value=value) for (key, value) in pool_info.items()}
     # get current block information & add to pool info
     current_block: BlockData = web3.eth.get_block(block_number)
     current_block_timestamp = current_block.get("timestamp")
@@ -163,16 +163,18 @@ def process_hyperdrive_checkpoint(checkpoint: dict[str, int], web3: Web3, block_
         A dict containing the checkpoint with some additional fields.
         This is what is expected by the chainsync db conversion function.
     """
+    out_checkpoint: dict[str, Any] = {}
+    out_checkpoint.update(checkpoint)
     current_block: BlockData = web3.eth.get_block(block_number)
     current_block_timestamp = current_block.get("timestamp")
     if current_block_timestamp is None:
         raise AssertionError("Current block has no timestamp")
-    checkpoint["blockNumber"] = int(block_number)
-    checkpoint["timestamp"] = datetime.fromtimestamp(current_block_timestamp)
-    checkpoint["sharePrice"] = FixedPoint(scaled_value=checkpoint["sharePrice"])
-    checkpoint["longSharePrice"] = FixedPoint(scaled_value=checkpoint["longSharePrice"])
-    checkpoint["longExposure"] = FixedPoint(scaled_value=checkpoint["longExposure"])
-    return checkpoint
+    out_checkpoint["blockNumber"] = int(block_number)
+    out_checkpoint["timestamp"] = datetime.fromtimestamp(int(current_block_timestamp))
+    out_checkpoint["sharePrice"] = FixedPoint(scaled_value=checkpoint["sharePrice"])
+    out_checkpoint["longSharePrice"] = FixedPoint(scaled_value=checkpoint["longSharePrice"])
+    out_checkpoint["longExposure"] = FixedPoint(scaled_value=checkpoint["longExposure"])
+    return out_checkpoint
 
 
 def get_hyperdrive_market(web3: Web3, hyperdrive_contract: Contract) -> HyperdriveMarket:

--- a/lib/ethpy/ethpy/hyperdrive/receipt_breakdown.py
+++ b/lib/ethpy/ethpy/hyperdrive/receipt_breakdown.py
@@ -1,0 +1,30 @@
+"""A container for hyperdrive contract return values."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fixedpointmath import FixedPoint
+
+
+@dataclass
+class ReceiptBreakdown:
+    r"""A granular breakdown of important values in a trade receipt."""
+    asset_id: int = 0
+    maturity_time_seconds: int = 0
+    base_amount: FixedPoint = FixedPoint(0)
+    bond_amount: FixedPoint = FixedPoint(0)
+    lp_amount: FixedPoint = FixedPoint(0)
+    withdrawal_share_amount: FixedPoint = FixedPoint(0)
+
+    def __post_init__(self):
+        if (
+            self.base_amount < 0
+            or self.bond_amount < 0
+            or self.maturity_time_seconds < 0
+            or self.lp_amount < 0
+            or self.withdrawal_share_amount < 0
+        ):
+            raise ValueError(
+                "All ReceiptBreakdown arguments must be positive,"
+                " since they are expected to be unsigned integer values from smart contracts."
+            )

--- a/tests/bot_to_db_test.py
+++ b/tests/bot_to_db_test.py
@@ -196,9 +196,8 @@ class TestBotToDb:
         # TODO these expected values are defined in lib/ethpy/ethpy/test_fixtures/deploy_hyperdrive.py
         # Eventually, we want to parameterize these values to pass into deploying hyperdrive
         expected_timestretch_fp = FixedPoint(scaled_value=_calculateTimeStretch(FixedPoint("0.05").scaled_value))
-        # TODO this is actually inv of solidity time stretch, fix
-        expected_timestretch = _to_unscaled_decimal((1 / expected_timestretch_fp))
-        expected_inv_timestretch = _to_unscaled_decimal(expected_timestretch_fp)
+        expected_timestretch = _to_unscaled_decimal(expected_timestretch_fp)
+        expected_inv_timestretch = _to_unscaled_decimal((1 / expected_timestretch_fp))
 
         expected_pool_config = {
             "contractAddress": hyperdrive_contract_addresses.mock_hyperdrive,
@@ -207,7 +206,6 @@ class TestBotToDb:
             "minimumShareReserves": _to_unscaled_decimal(FixedPoint("10")),
             "positionDuration": 604800,  # 1 week
             "checkpointDuration": 3600,  # 1 hour
-            # TODO this is actually inv of solidity time stretch, fix
             "timeStretch": expected_timestretch,
             "governance": deploy_account.address,
             "feeCollector": deploy_account.address,


### PR DESCRIPTION
This PR is to create a higher-level interface for the hyperdrive contract. Presently, the primary consumer of this API will be agent0.

The api is primarily following specs from the front-end team's `hyperdrive-js` sdk. It will ultimately wrap
- pypechain: types, errors, structs, etc
- pyperdrive: static functions such as get_max_long, get_spot_price, etc
- ethpy.hyperdrive: more convenient interface for trades (open_long, etc), getting the pool state & config, etc

This PR is a first step, and does not include all of the desired features.

The API currently provides the following endpoints:
- hyperdrive.web3
- hyperdrive.hyperdrive_contract
- hyperdrive.base_token_contract
- hyperdrive.get_get_eth_base_balances(address)
- hyperdrive.last_state_block_number
- hyperdrive.pool_config
- hyperdrive.pool_info
- hyperdrive.latest_checkpoint
- hyperdrive.current_block
- hyperdrive.current_block_number
- hyperdrive.current_block_time
- hyperdrive.spot_price
- hyperdrive.get_max_long(FixedPoint(1000))
- hyperdrive.get_max_short(FixedPoint(1000))