### PR TITLE
Streamlit performance optimizations

### DIFF
--- a/lib/chainsync/bin/streamlit/Dashboard.py
+++ b/lib/chainsync/bin/streamlit/Dashboard.py
@@ -55,7 +55,7 @@ ticker_placeholder = st.empty()
 main_placeholder = st.empty()
 
 plt.close("all")
-main_fig = mpf.figure(style="mike", figsize=(15, 15))
+main_fig = mpf.figure(style="mike", figsize=(10, 10))
 # matplotlib doesn't play nice with types
 (ax_ohlcv, ax_fixed_rate, ax_positions) = main_fig.subplots(3, 1, sharex=True)  # type: ignore
 

--- a/lib/chainsync/bin/streamlit/Dashboard.py
+++ b/lib/chainsync/bin/streamlit/Dashboard.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import gc
 import time
 
 import matplotlib.pyplot as plt
@@ -34,6 +35,9 @@ from ethpy import build_eth_config
 
 # pylint: disable=invalid-name
 
+plt.close("all")
+gc.collect()
+
 st.set_page_config(page_title="Trading Competition Dashboard", layout="wide")
 st.set_option("deprecation.showPyplotGlobalUse", False)
 
@@ -54,7 +58,6 @@ ticker_placeholder = st.empty()
 # OHLCV
 main_placeholder = st.empty()
 
-plt.close("all")
 main_fig = mpf.figure(style="mike", figsize=(10, 10))
 # matplotlib doesn't play nice with types
 (ax_ohlcv, ax_fixed_rate, ax_positions) = main_fig.subplots(3, 1, sharex=True)  # type: ignore

--- a/lib/chainsync/bin/streamlit/Dashboard.py
+++ b/lib/chainsync/bin/streamlit/Dashboard.py
@@ -48,7 +48,7 @@ config_data = get_pool_config(session, coerce_float=False)
 
 config_data = config_data.iloc[0]
 
-max_live_blocks = 14400
+max_live_blocks = 5000
 # Live ticker
 ticker_placeholder = st.empty()
 # OHLCV

--- a/lib/chainsync/bin/streamlit/pages/Wallet_Stats.py
+++ b/lib/chainsync/bin/streamlit/pages/Wallet_Stats.py
@@ -15,7 +15,7 @@ st.set_option("deprecation.showPyplotGlobalUse", False)
 
 # TODO clean up this script into various functions
 
-MAX_LIVE_BLOCKS = 14400
+MAX_LIVE_BLOCKS = 5000
 
 # Load and connect to postgres
 session = initialize_session()

--- a/lib/chainsync/bin/streamlit/pages/Wallet_Stats.py
+++ b/lib/chainsync/bin/streamlit/pages/Wallet_Stats.py
@@ -98,7 +98,7 @@ wallet_positions["username"] = (
 
 # Plot pnl over time
 plt.close("all")
-main_fig = mpf.figure(style="mike", figsize=(15, 15))
+main_fig = mpf.figure(style="mike", figsize=(10, 10))
 # matplotlib doesn't play nice with types
 (ax_pnl, ax_base, ax_long, ax_short, ax_lp, ax_withdraw) = main_fig.subplots(6, 1, sharex=True)  # type: ignore
 

--- a/lib/chainsync/bin/streamlit/pages/Wallet_Stats.py
+++ b/lib/chainsync/bin/streamlit/pages/Wallet_Stats.py
@@ -3,6 +3,8 @@
 # Streamlit gets the name of the sidebar tab from the name of the file
 # hence, this file is capitalized
 
+import gc
+
 import matplotlib.pyplot as plt
 import mplfinance as mpf
 import streamlit as st
@@ -15,6 +17,9 @@ from chainsync.db.hyperdrive import (
     get_wallet_pnl,
     get_wallet_positions_over_time,
 )
+
+plt.close("all")
+gc.collect()
 
 st.set_page_config(page_title="Trading Competition Dashboard", layout="wide")
 st.set_option("deprecation.showPyplotGlobalUse", False)
@@ -97,7 +102,6 @@ wallet_positions["username"] = (
 
 
 # Plot pnl over time
-plt.close("all")
 main_fig = mpf.figure(style="mike", figsize=(10, 10))
 # matplotlib doesn't play nice with types
 (ax_pnl, ax_base, ax_long, ax_short, ax_lp, ax_withdraw) = main_fig.subplots(6, 1, sharex=True)  # type: ignore

--- a/lib/chainsync/chainsync/db/hyperdrive/__init__.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/__init__.py
@@ -25,10 +25,12 @@ from .interface import (
     get_pool_config,
     get_pool_info,
     get_ticker,
+    get_total_wallet_pnl_over_time,
     get_transactions,
     get_wallet_deltas,
     get_wallet_info_history,
     get_wallet_pnl,
+    get_wallet_positions_over_time,
 )
 from .schema import (
     CheckpointInfo,

--- a/lib/chainsync/chainsync/db/hyperdrive/interface.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/interface.py
@@ -8,18 +8,9 @@ from chainsync.db.base import get_latest_block_number_from_table
 from sqlalchemy import exc, func
 from sqlalchemy.orm import Session
 
-from .schema import (
-    CheckpointInfo,
-    CurrentWallet,
-    HyperdriveTransaction,
-    PoolAnalysis,
-    PoolConfig,
-    PoolInfo,
-    Ticker,
-    WalletDelta,
-    WalletInfoFromChain,
-    WalletPNL,
-)
+from .schema import (CheckpointInfo, CurrentWallet, HyperdriveTransaction,
+                     PoolAnalysis, PoolConfig, PoolInfo, Ticker, WalletDelta,
+                     WalletInfoFromChain, WalletPNL)
 
 
 def add_transactions(transactions: list[HyperdriveTransaction], session: Session) -> None:
@@ -733,6 +724,8 @@ def get_ticker(
     end_block : int | None, optional
         The ending block to filter the query on. end_block integers
         matches python slicing notation, e.g., list[:3], list[:-3]
+    wallet_address : list[str] | None, optional
+        The wallet addresses to filter the query on
     coerce_float : bool
         If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
 
@@ -785,6 +778,10 @@ def get_wallet_pnl(
     end_block : int | None, optional
         The ending block to filter the query on. end_block integers
         matches python slicing notation, e.g., list[:3], list[:-3]
+    wallet_address : list[str] | None, optional
+        The wallet addresses to filter the query on. Returns all if None.
+    return_timestamp : bool, optional
+        Returns the timestamp from the pool info table if True. Defaults to True.
     coerce_float : bool
         If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
 
@@ -828,7 +825,7 @@ def get_total_wallet_pnl_over_time(
     wallet_address: list[str] | None = None,
     coerce_float=True,
 ) -> pd.DataFrame:
-    """Get all pool analysis and returns as a pandas dataframe.
+    """Get total pnl across wallets over time and returns as a pandas dataframe.
 
     Arguments
     ---------
@@ -840,6 +837,8 @@ def get_total_wallet_pnl_over_time(
     end_block : int | None, optional
         The ending block to filter the query on. end_block integers
         matches python slicing notation, e.g., list[:3], list[:-3]
+    wallet_address : list[str] | None, optional
+        The wallet addresses to filter the query on. Returns all if None.
     coerce_float : bool
         If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
 
@@ -888,7 +887,7 @@ def get_wallet_positions_over_time(
     wallet_address: list[str] | None = None,
     coerce_float=True,
 ) -> pd.DataFrame:
-    """Get all pool analysis and returns as a pandas dataframe.
+    """Get wallet positions over time and returns as a pandas dataframe.
 
     Arguments
     ---------
@@ -900,6 +899,8 @@ def get_wallet_positions_over_time(
     end_block : int | None, optional
         The ending block to filter the query on. end_block integers
         matches python slicing notation, e.g., list[:3], list[:-3]
+    wallet_address : list[str] | None, optional
+        The wallet addresses to filter the query on. Returns all if None.
     coerce_float : bool
         If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
 

--- a/lib/chainsync/chainsync/db/hyperdrive/interface.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/interface.py
@@ -8,9 +8,18 @@ from chainsync.db.base import get_latest_block_number_from_table
 from sqlalchemy import exc, func
 from sqlalchemy.orm import Session
 
-from .schema import (CheckpointInfo, CurrentWallet, HyperdriveTransaction,
-                     PoolAnalysis, PoolConfig, PoolInfo, Ticker, WalletDelta,
-                     WalletInfoFromChain, WalletPNL)
+from .schema import (
+    CheckpointInfo,
+    CurrentWallet,
+    HyperdriveTransaction,
+    PoolAnalysis,
+    PoolConfig,
+    PoolInfo,
+    Ticker,
+    WalletDelta,
+    WalletInfoFromChain,
+    WalletPNL,
+)
 
 
 def add_transactions(transactions: list[HyperdriveTransaction], session: Session) -> None:

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -23,7 +23,7 @@ _SLEEP_AMOUNT = 1
 # pylint: disable=too-many-arguments
 def acquire_data(
     start_block: int = 0,
-    lookback_block_limit: int = 5000,
+    lookback_block_limit: int = 1000,
     eth_config: EthConfig | None = None,
     db_session: Session | None = None,
     contract_addresses: HyperdriveAddresses | None = None,

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+import warnings
 
 from chainsync.db.base import initialize_session
 from chainsync.db.hyperdrive import (
@@ -17,6 +18,8 @@ from ethpy.hyperdrive import HyperdriveAddresses, fetch_hyperdrive_address_from_
 from sqlalchemy.orm import Session
 
 _SLEEP_AMOUNT = 1
+
+warnings.filterwarnings("ignore", category=UserWarning, module="web3.contract.base_contract")
 
 
 # Lots of arguments

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -23,7 +23,7 @@ _SLEEP_AMOUNT = 1
 # pylint: disable=too-many-arguments
 def acquire_data(
     start_block: int = 0,
-    lookback_block_limit: int = 10000,
+    lookback_block_limit: int = 8000,
     eth_config: EthConfig | None = None,
     db_session: Session | None = None,
     contract_addresses: HyperdriveAddresses | None = None,
@@ -104,6 +104,11 @@ def acquire_data(
             logging.info("Block %s", block_number)
             # Explicit check against loopback block limit
             if (latest_mined_block - block_number) > lookback_block_limit:
+                # NOTE when this case happens, wallet information will no longer
+                # be accurate, as we may have missed deltas on wallets
+                # based on the blocks we skipped
+                # TODO should directly query the chain for open positions
+                # in this case
                 logging.warning(
                     "Querying block_number %s out of %s, unable to keep up with chain block iteration",
                     block_number,

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -23,7 +23,7 @@ _SLEEP_AMOUNT = 1
 # pylint: disable=too-many-arguments
 def acquire_data(
     start_block: int = 0,
-    lookback_block_limit: int = 8000,
+    lookback_block_limit: int = 5000,
     eth_config: EthConfig | None = None,
     db_session: Session | None = None,
     contract_addresses: HyperdriveAddresses | None = None,

--- a/lib/chainsync/chainsync/exec/data_analysis.py
+++ b/lib/chainsync/chainsync/exec/data_analysis.py
@@ -96,6 +96,7 @@ def data_analysis(
                 break
             continue
         # Does batch analysis on range(analysis_start_block, latest_data_block_number) blocks
+        # TODO do regular batching to sample for wallet information
         analysis_start_block = block_number + 1
         analysis_end_block = latest_data_block_number + 1
         logging.info("Running batch %s to %s", analysis_start_block, analysis_end_block)


### PR DESCRIPTION
Adjusting streamlit to be more performant under high volume.

- Reducing dashboard view from 14400 blocks to 5000 blocks
- Moving groupby computation for positions over time to be on the sql side instead of pandas side in streamlit
- Shortening loopback limit so acquire_data doesn't break when chain spins faster than data pipeline
- Smaller fig sizes for faster plotting
- Explicit figure closing and garbage collection
- Removing warning printing on data collection from web3 for performance

Overall, there is still a memory leak, with a description, fixed within infra, and suggestions on longer term fixed detailed here: (https://github.com/delvtech/elf-simulations/issues/891)