### PR TITLE
override variables in load_dotenv

### DIFF
--- a/lib/agent0/agent0/accounts_config.py
+++ b/lib/agent0/agent0/accounts_config.py
@@ -190,7 +190,7 @@ def build_account_config_from_env(env_file: str | None = None, user_key: str | N
         env_file = "account.env"
 
     # Look for and load local config if it exists
-    load_dotenv(env_file)
+    load_dotenv(env_file, override=True)
 
     if user_key is None:
         # USER PRIVATE KEY


### PR DESCRIPTION
allows running agents with different confgis one after another. otherwise, the first config is not replaced in memory, causing an error.