### PR TITLE
pypechain: make it drier

### DIFF
--- a/lib/pypechain/pypechain/run_pypechain.py
+++ b/lib/pypechain/pypechain/run_pypechain.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import black
 from black.mode import Mode  # pylint: disable=no-name-in-module
 from jinja2 import Template
+from web3.types import ABIFunction
+
 from pypechain.utilities.abi import (
     get_abi_items,
     get_events_for_abi,
@@ -20,7 +22,6 @@ from pypechain.utilities.abi import (
 from pypechain.utilities.format import avoid_python_keywords, capitalize_first_letter_only
 from pypechain.utilities.templates import setup_templates
 from pypechain.utilities.types import solidity_to_python_type
-from web3.types import ABIFunction
 
 
 def format_code(code):
@@ -35,7 +36,7 @@ def format_code(code):
 
 
 def write_code(path, code):
-    """save to specified path the provided code."""
+    """Save to specified path the provided code."""
     with open(path, "w", encoding="utf-8") as output_file:
         output_file.write(code)
 
@@ -51,7 +52,6 @@ def main(abi_file_path: str, output_dir: str) -> None:
     output_dr: str
         Path to the directory to output the generated files.
     """
-
     # get names
     file_path = Path(abi_file_path)
     filename = file_path.name
@@ -92,7 +92,6 @@ def render_contract_file(contract_name: str, contract_template: Template, abi_fi
     str
         A serialized python file.
     """
-
     # TODO:  return types to function calls
     # Extract function names and their input parameters from the ABI
     abi_functions_and_events = get_abi_items(abi_file_path)
@@ -109,7 +108,7 @@ def render_contract_file(contract_name: str, contract_template: Template, abi_fi
                 "capitalized_name": capitalize_first_letter_only(name),
                 "input_names_and_types": get(abi_function, "inputs", include_types=True),
                 "input_names": get(abi_function, "inputs", include_types=False),
-                "outputs": get(abi_function, "outputs", include_types=True),
+                "outputs": get(abi_function, "outputs", include_types=False),
             }
             function_datas.append(function_data)
     # Render the template
@@ -131,7 +130,6 @@ def render_types_file(contract_name: str, types_template: Template, abi_file_pat
     str
         A serialized python file.
     """
-
     abi = load_abi_from_file(abi_file_path)
 
     structs_by_name = get_structs_for_abi(abi)
@@ -144,7 +142,7 @@ def render_types_file(contract_name: str, types_template: Template, abi_file_pat
 def get(function: ABIFunction, param_type, include_types: bool = True) -> list[str] | dict[str, str]:
     """Returns function inputs or outputs, optionally including types."""
     params = get_params(param_type, function)
-    return params if include_types else [f"{k}: {v}" for k,v in params.items()]
+    return [f"{k}: {v}" for k,v in params.items()] if include_types else list(params.keys())
 
 
 def get_params(param_type, function) -> dict[str, str]:

--- a/lib/pypechain/pypechain/run_pypechain.py
+++ b/lib/pypechain/pypechain/run_pypechain.py
@@ -139,10 +139,11 @@ def render_types_file(contract_name: str, types_template: Template, abi_file_pat
 
     return types_template.render(contract_name=contract_name, structs=structs, events=events)
 
+
 def get(function: ABIFunction, param_type, include_types: bool = True) -> list[str] | dict[str, str]:
     """Returns function inputs or outputs, optionally including types."""
     params = get_params(param_type, function)
-    return [f"{k}: {v}" for k,v in params.items()] if include_types else list(params.keys())
+    return [f"{k}: {v}" for k, v in params.items()] if include_types else list(params.keys())
 
 
 def get_params(param_type, function) -> dict[str, str]:

--- a/lib/pypechain/pypechain/templates/contract.jinja2
+++ b/lib/pypechain/pypechain/templates/contract.jinja2
@@ -8,11 +8,11 @@ from web3.contract.contract import Contract, ContractFunction, ContractFunctions
 from web3.exceptions import FallbackNotFound
 
 {% for function in functions %}
-class {{contract_name}}{{function.capitalized_name}}ContractFunction(ContractFunction):
+class {{function.capitalized_name}}(ContractFunction):
     """ContractFunction for the {{function.name}} method."""
 
     # pylint: disable=arguments-differ
-    def __call__(self, {{function.input_names_and_types|join(', ')}}) -> "{{contract_name}}{{function.capitalized_name}}ContractFunction":
+    def __call__(self, {{function.input_names_and_types|join(', ')}}) -> "{{function.capitalized_name}}":
         super().__call__({{function.input_names|join(', ')}})
         return self
     # TODO: add call def so we can get return types for the calls
@@ -24,7 +24,7 @@ class {{contract_name}}{{function.capitalized_name}}ContractFunction(ContractFun
 class {{contract_name}}ContractFunctions(ContractFunctions):
     """ContractFunctions for the {{contract_name}} contract."""
 {% for function in functions %}
-    {{function.name}}: {{contract_name}}{{function.capitalized_name}}ContractFunction
+    {{function.name}}: {{function.capitalized_name}}
 {% endfor %}
 
 class {{contract_name}}Contract(Contract):

--- a/lib/pypechain/pypechain/templates/contract.jinja2
+++ b/lib/pypechain/pypechain/templates/contract.jinja2
@@ -8,11 +8,11 @@ from web3.contract.contract import Contract, ContractFunction, ContractFunctions
 from web3.exceptions import FallbackNotFound
 
 {% for function in functions %}
-class {{function.capitalized_name}}(ContractFunction):
+class {{contract_name}}{{function.capitalized_name}}ContractFunction(ContractFunction):
     """ContractFunction for the {{function.name}} method."""
 
     # pylint: disable=arguments-differ
-    def __call__(self, {{function.input_names_and_types|join(', ')}}) -> "{{function.capitalized_name}}":
+    def __call__(self, {{function.input_names_and_types|join(', ')}}) -> "{{contract_name}}{{function.capitalized_name}}ContractFunction":
         super().__call__({{function.input_names|join(', ')}})
         return self
     # TODO: add call def so we can get return types for the calls
@@ -24,7 +24,7 @@ class {{function.capitalized_name}}(ContractFunction):
 class {{contract_name}}ContractFunctions(ContractFunctions):
     """ContractFunctions for the {{contract_name}} contract."""
 {% for function in functions %}
-    {{function.name}}: {{function.capitalized_name}}
+    {{function.name}}: {{contract_name}}{{function.capitalized_name}}ContractFunction
 {% endfor %}
 
 class {{contract_name}}Contract(Contract):

--- a/lib/pypechain/pypechain/utilities/abi.py
+++ b/lib/pypechain/pypechain/utilities/abi.py
@@ -87,7 +87,7 @@ def is_abi_function(item: ABIElement) -> TypeGuard[ABIFunction]:
     required_keys = ["type", "name", "inputs"]
 
     # Check if the required keys exist
-    if not all(key in item for key in required_keys):
+    if any(key not in item for key in required_keys):
         return False
 
     # Check if the type is "function"
@@ -113,7 +113,7 @@ def is_abi_event(item: ABIElement) -> TypeGuard[ABIEvent]:
     required_keys = ["type", "name", "inputs"]
 
     # Check if the required keys exist
-    if not all(key in item for key in required_keys):
+    if any(key not in item for key in required_keys):
         return False
 
     # Check if the type is "event"

--- a/lib/pypechain/pyproject.toml
+++ b/lib/pypechain/pyproject.toml
@@ -15,6 +15,12 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
+[tool.pylint.format]
+max-line-length = "120"
+
+[tool.black]
+line-length = "120"
+
 [project.optional-dependencies]
 # This flag installs all dependencies and should be ran when installing this subpackage in isolation
 with-dependencies = ["pypechain[base]"]


### PR DESCRIPTION
- replace `get_input_names` and `get_input_names_and_values` with single `get` function
- replace `stringify_parameters` with `get` which renames anonymous functions to input1, output2, etc.
- simplify conditional statement in abi.py
- lint
