### PR TITLE
consistent naming of URIs

### DIFF
--- a/eth.env.sample
+++ b/eth.env.sample
@@ -1,3 +1,3 @@
-RPC_URL="localhost:8545"
-ARTIFACTS_URL="localhost:8080"
+RPC_URI="localhost:8545"
+ARTIFACTS_URI="localhost:8080"
 ABI_DIR="./packages/hyperdrive/src/abis"

--- a/lib/agent0/agent0/base/config/environment_config.py
+++ b/lib/agent0/agent0/base/config/environment_config.py
@@ -37,8 +37,8 @@ class EnvironmentConfig(types.FrozenClass):
     max_bytes: int = DEFAULT_LOG_MAXBYTES  # int(2e6) or 2MB
     # int to be used for the random seed
     random_seed: int = 1
-    # username registration url
-    username_register_url: str = "http://localhost:5002"
+    # username registration URI
+    username_register_uri: str = "http://localhost:5002"
 
     def __getitem__(self, attrib) -> None:
         return getattr(self, attrib)

--- a/lib/agent0/agent0/hyperdrive/exec/create_and_fund_user_account.py
+++ b/lib/agent0/agent0/hyperdrive/exec/create_and_fund_user_account.py
@@ -20,7 +20,7 @@ def create_and_fund_user_account(
     Arguments
     ---------
     eth_config: EthConfig
-        Configuration for urls to the rpc and artifacts.
+        Configuration for URIs to the rpc and artifacts.
     account_key_config: AccountKeyConfig
         Configuration linking to the env file for storing private keys and initial budgets.
         Defines the agents to be funded.

--- a/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
@@ -31,7 +31,7 @@ def fund_agents(
     user_account : HyperdriveAgent
         The HyperdriveAgent corresponding to the user account to fund the agents.
     eth_config: EthConfig
-        Configuration for urls to the rpc and artifacts.
+        Configuration for URIs to the rpc and artifacts.
     account_key_config: AccountKeyConfig
         Configuration linking to the env file for storing private keys and initial budgets.
         Defines the agents to be funded.
@@ -42,9 +42,9 @@ def fund_agents(
         HyperdriveAgent(Account().from_key(agent_private_key)) for agent_private_key in account_key_config.AGENT_KEYS
     ]
 
-    web3 = initialize_web3_with_http_provider(eth_config.RPC_URL, reset_provider=False)
+    web3 = initialize_web3_with_http_provider(eth_config.rpc_uri, reset_provider=False)
     abi_file_loc = os.path.join(
-        os.path.join(eth_config.ABI_DIR, "ERC20Mintable.sol"),
+        os.path.join(eth_config.abi_dir, "ERC20Mintable.sol"),
         "ERC20Mintable.json",
     )
     base_contract_abi = load_abi_from_file(abi_file_loc)

--- a/lib/agent0/agent0/hyperdrive/exec/run_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/run_agents.py
@@ -9,7 +9,7 @@ from agent0 import AccountKeyConfig
 from agent0.base.config import DEFAULT_USERNAME, AgentConfig, EnvironmentConfig
 from eth_typing import BlockNumber
 from ethpy import EthConfig, build_eth_config
-from ethpy.hyperdrive import HyperdriveAddresses, fetch_hyperdrive_address_from_url
+from ethpy.hyperdrive import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
 
 from .create_and_fund_user_account import create_and_fund_user_account
 from .fund_agents import fund_agents
@@ -41,10 +41,10 @@ def run_agents(
     develop: bool
         Flag for development mode.
     eth_config: EthConfig | None
-        Configuration for urls to the rpc and artifacts. If not set, will look for addresses
+        Configuration for URIs to the rpc and artifacts. If not set, will look for addresses
         in eth.env.
     contract_addresses: HyperdriveAddresses | None
-        If set, will use these addresses instead of querying the artifact url
+        If set, will use these addresses instead of querying the artifact URI
         defined in eth_config.
     """
 
@@ -57,9 +57,9 @@ def run_agents(
     if eth_config is None:
         eth_config = build_eth_config()
 
-    # Get addresses either from artifacts url defined in eth_config or from contract_addresses
+    # Get addresses either from artifacts URI defined in eth_config or from contract_addresses
     if contract_addresses is None:
-        contract_addresses = fetch_hyperdrive_address_from_url(os.path.join(eth_config.ARTIFACTS_URL, "addresses.json"))
+        contract_addresses = fetch_hyperdrive_address_from_uri(os.path.join(eth_config.artifacts_uri, "addresses.json"))
 
     if develop:  # setup env automatically & fund the agents
         # exposing the user account for debugging purposes
@@ -82,7 +82,7 @@ def run_agents(
         # Set up postgres to write username to agent wallet addr
         # initialize the postgres session
         wallet_addrs = [str(agent.checksum_address) for agent in agent_accounts]
-        register_username(environment_config.username_register_url, wallet_addrs, environment_config.username)
+        register_username(environment_config.username_register_uri, wallet_addrs, environment_config.username)
 
     last_executed_block = BlockNumber(0)
     while True:

--- a/lib/agent0/agent0/hyperdrive/exec/setup_experiment.py
+++ b/lib/agent0/agent0/hyperdrive/exec/setup_experiment.py
@@ -30,7 +30,7 @@ def setup_experiment(
     Arguments
     ---------
     eth_config: EthConfig
-        Configuration for urls to the rpc and artifacts.
+        Configuration for URIs to the rpc and artifacts.
     environment_config: EnvironmentConfig
         The agent's environment configuration.
     agent_config: list[AgentConfig]
@@ -73,12 +73,12 @@ def setup_experiment(
     return web3, base_token_contract, hyperdrive_contract, agent_accounts
 
 
-def register_username(register_url: str, wallet_addrs: list[str], username: str) -> None:
+def register_username(register_uri: str, wallet_addrs: list[str], username: str) -> None:
     """Registers the username with the flask server.
 
     Arguments
     ---------
-    register_url: str
+    register_uri: str
         The endpoint for the flask server.
     wallet_addrs: list[str]
         The list of wallet addresses to register.
@@ -87,6 +87,6 @@ def register_username(register_url: str, wallet_addrs: list[str], username: str)
     """
     # TODO: use the json schema from the server.
     json_data = {"wallet_addrs": wallet_addrs, "username": username}
-    result = requests.post(f"{register_url}/register_agents", json=json_data, timeout=3)
+    result = requests.post(f"{register_uri}/register_agents", json=json_data, timeout=3)
     if result.status_code != HTTPStatus.OK:
         raise ConnectionError(result)

--- a/lib/agent0/bin/checkpoint_bot.py
+++ b/lib/agent0/bin/checkpoint_bot.py
@@ -19,7 +19,7 @@ from ethpy.base import (
     smart_contract_read,
     smart_contract_transact,
 )
-from ethpy.hyperdrive import fetch_hyperdrive_address_from_url, get_hyperdrive_config
+from ethpy.hyperdrive import fetch_hyperdrive_address_from_uri, get_hyperdrive_config
 from fixedpointmath import FixedPoint
 from web3.contract.contract import Contract
 
@@ -57,7 +57,7 @@ def main() -> None:
     # pylint: disable=too-many-locals
     eth_config, env_config = get_config()
 
-    web3 = initialize_web3_with_http_provider(eth_config.RPC_URL, reset_provider=False)
+    web3 = initialize_web3_with_http_provider(eth_config.rpc_uri, reset_provider=False)
 
     # Setup logging
     logs.setup_logging(
@@ -76,8 +76,8 @@ def main() -> None:
     logging.info("Successfully funded the sender=%s.", sender.address)
 
     # Get the Hyperdrive contract.
-    hyperdrive_abis = load_all_abis(eth_config.ABI_DIR)
-    addresses = fetch_hyperdrive_address_from_url(os.path.join(eth_config.ARTIFACTS_URL, "addresses.json"))
+    hyperdrive_abis = load_all_abis(eth_config.abi_dir)
+    addresses = fetch_hyperdrive_address_from_uri(os.path.join(eth_config.artifacts_uri, "addresses.json"))
     hyperdrive_contract: Contract = web3.eth.contract(
         abi=hyperdrive_abis["IHyperdrive"],
         address=web3.to_checksum_address(addresses.mock_hyperdrive),

--- a/lib/agent0/bin/fund_agents_from_user_key.py
+++ b/lib/agent0/bin/fund_agents_from_user_key.py
@@ -9,7 +9,7 @@ from agent0.hyperdrive.agents import HyperdriveAgent
 from agent0.hyperdrive.exec import fund_agents
 from eth_account.account import Account
 from ethpy import build_eth_config
-from ethpy.hyperdrive import fetch_hyperdrive_address_from_url
+from ethpy.hyperdrive import fetch_hyperdrive_address_from_uri
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -45,7 +45,7 @@ if __name__ == "__main__":
         raise ValueError("User key not provided as argument, and was not found in env file")
 
     eth_config = build_eth_config()
-    contract_addresses = fetch_hyperdrive_address_from_url(os.path.join(eth_config.ARTIFACTS_URL, "addresses.json"))
+    contract_addresses = fetch_hyperdrive_address_from_uri(os.path.join(eth_config.artifacts_uri, "addresses.json"))
     user_account = HyperdriveAgent(Account().from_key(account_key_config.USER_KEY))
 
     fund_agents(user_account, eth_config, account_key_config, contract_addresses)

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -13,7 +13,7 @@ from chainsync.db.hyperdrive import (
 )
 from eth_typing import BlockNumber
 from ethpy import EthConfig, build_eth_config
-from ethpy.hyperdrive import HyperdriveAddresses, fetch_hyperdrive_address_from_url, get_web3_and_hyperdrive_contracts
+from ethpy.hyperdrive import HyperdriveAddresses, fetch_hyperdrive_address_from_uri, get_web3_and_hyperdrive_contracts
 from sqlalchemy.orm import Session
 
 _SLEEP_AMOUNT = 1
@@ -38,13 +38,13 @@ def acquire_data(
     lookback_block_limit : int
         The maximum number of blocks to look back when filling in missing data
     eth_config: EthConfig | None
-        Configuration for urls to the rpc and artifacts. If not set, will look for addresses
+        Configuration for URIs to the rpc and artifacts. If not set, will look for addresses
         in eth.env.
     db_session: Session | None
         Session object for connecting to db. If None, will initialize a new session based on
         postgres.env.
     contract_addresses: HyperdriveAddresses | None
-        If set, will use these addresses instead of querying the artifact url
+        If set, will use these addresses instead of querying the artifact URI
         defined in eth_config.
     exit_on_catch_up: bool
         If True, will exit after catching up to current block
@@ -59,9 +59,9 @@ def acquire_data(
     if db_session is None:
         db_session = initialize_session()
 
-    # Get addresses either from artifacts url defined in eth_config or from contract_addresses
+    # Get addresses either from artifacts URI defined in eth_config or from contract_addresses
     if contract_addresses is None:
-        contract_addresses = fetch_hyperdrive_address_from_url(os.path.join(eth_config.ARTIFACTS_URL, "addresses.json"))
+        contract_addresses = fetch_hyperdrive_address_from_uri(os.path.join(eth_config.artifacts_uri, "addresses.json"))
 
     # Get web3 and contracts
     web3, base_contract, hyperdrive_contract = get_web3_and_hyperdrive_contracts(eth_config, contract_addresses)

--- a/lib/chainsync/chainsync/exec/data_analysis.py
+++ b/lib/chainsync/chainsync/exec/data_analysis.py
@@ -13,7 +13,7 @@ from chainsync.db.hyperdrive import (
     get_pool_config,
 )
 from ethpy import EthConfig, build_eth_config
-from ethpy.hyperdrive import HyperdriveAddresses, fetch_hyperdrive_address_from_url, get_web3_and_hyperdrive_contracts
+from ethpy.hyperdrive import HyperdriveAddresses, fetch_hyperdrive_address_from_uri, get_web3_and_hyperdrive_contracts
 from sqlalchemy.orm import Session
 
 _SLEEP_AMOUNT = 1
@@ -35,13 +35,13 @@ def data_analysis(
     lookback_block_limit : int
         The maximum number of blocks to look back when filling in missing data
     eth_config: EthConfig | None
-        Configuration for urls to the rpc and artifacts. If not set, will look for addresses
+        Configuration for URIs to the rpc and artifacts. If not set, will look for addresses
         in eth.env.
     db_session: Session | None
         Session object for connecting to db. If None, will initialize a new session based on
         postgres.env.
     contract_addresses: HyperdriveAddresses | None
-        If set, will use these addresses instead of querying the artifact url
+        If set, will use these addresses instead of querying the artifact URI
         defined in eth_config.
     exit_on_catch_up: bool
         If True, will exit after catching up to current block
@@ -56,9 +56,9 @@ def data_analysis(
     if db_session is None:
         db_session = initialize_session()
 
-    # Get addresses either from artifacts url defined in eth_config or from contract_addresses
+    # Get addresses either from artifacts URI defined in eth_config or from contract_addresses
     if contract_addresses is None:
-        contract_addresses = fetch_hyperdrive_address_from_url(os.path.join(eth_config.ARTIFACTS_URL, "addresses.json"))
+        contract_addresses = fetch_hyperdrive_address_from_uri(os.path.join(eth_config.artifacts_uri, "addresses.json"))
 
     # Get hyperdrive contract
     _, _, hyperdrive_contract = get_web3_and_hyperdrive_contracts(eth_config, contract_addresses)

--- a/lib/ethpy/ethpy/eth_config.py
+++ b/lib/ethpy/ethpy/eth_config.py
@@ -22,9 +22,6 @@ class EthConfig:
         The path to the abi directory.
     """
 
-    # default values for local contracts
-    # Matching environment variables to search for
-    # pylint: disable=invalid-name
     artifacts_uri: URI | str = URI("http://localhost:8080")
     rpc_uri: URI | str = URI("http://localhost:8545")
     abi_dir: str = "./packages/hyperdrive/src/abis"
@@ -54,9 +51,9 @@ def build_eth_config() -> EthConfig:
 
     arg_dict = {}
     if artifacts_uri is not None:
-        arg_dict["ARTIFACTS_URI"] = artifacts_uri
+        arg_dict["artifacts_uri"] = artifacts_uri
     if rpc_uri is not None:
-        arg_dict["RPC_URI"] = rpc_uri
+        arg_dict["rpc_uri"] = rpc_uri
     if abi_dir is not None:
-        arg_dict["ABI_DIR"] = abi_dir
+        arg_dict["abi_dir"] = abi_dir
     return EthConfig(**arg_dict)

--- a/lib/ethpy/ethpy/eth_config.py
+++ b/lib/ethpy/ethpy/eth_config.py
@@ -54,9 +54,9 @@ def build_eth_config() -> EthConfig:
 
     arg_dict = {}
     if artifacts_uri is not None:
-        arg_dict["ARTIFACTS_URL"] = artifacts_uri
+        arg_dict["ARTIFACTS_URI"] = artifacts_uri
     if rpc_uri is not None:
-        arg_dict["RPC_URL"] = rpc_uri
+        arg_dict["RPC_URI"] = rpc_uri
     if abi_dir is not None:
         arg_dict["ABI_DIR"] = abi_dir
     return EthConfig(**arg_dict)

--- a/lib/ethpy/ethpy/eth_config.py
+++ b/lib/ethpy/ethpy/eth_config.py
@@ -1,4 +1,5 @@
 """Defines the eth chain connection configuration from env vars."""
+from __future__ import annotations
 
 import os
 from dataclasses import dataclass
@@ -13,20 +14,26 @@ class EthConfig:
 
     Attributes
     ----------
-    ARTIFACTS_URL: str
-        The url of the artifacts server from which we get addresses.
-    RPC_URL: URI | str
-        The url to the ethereum node
-    ABI_DIR: str
-        The path to the abi directory
+    artifacts_uri: URI | str
+        The uri of the artifacts server from which we get addresses.
+    rpc_uri: URI | str
+        The uri to the ethereum node.
+    abi_dir: str
+        The path to the abi directory.
     """
 
     # default values for local contracts
     # Matching environment variables to search for
     # pylint: disable=invalid-name
-    ARTIFACTS_URL: str = "http://localhost:8080"
-    RPC_URL: URI = URI("http://localhost:8545")
-    ABI_DIR: str = "./packages/hyperdrive/src/abis"
+    artifacts_uri: URI | str = URI("http://localhost:8080")
+    rpc_uri: URI | str = URI("http://localhost:8545")
+    abi_dir: str = "./packages/hyperdrive/src/abis"
+
+    def __post_init__(self):
+        if isinstance(self.artifacts_uri, str):
+            self.artifacts_uri = URI(self.artifacts_uri)
+        if isinstance(self.rpc_uri, str):
+            self.rpc_uri = URI(self.rpc_uri)
 
 
 def build_eth_config() -> EthConfig:
@@ -41,15 +48,15 @@ def build_eth_config() -> EthConfig:
     # Look for and load local config if it exists
     load_dotenv("eth.env")
 
-    artifacts_url = os.getenv("ARTIFACTS_URL")
-    rpc_url = os.getenv("RPC_URL")
+    artifacts_uri = os.getenv("ARTIFACTS_URI")
+    rpc_uri = os.getenv("RPC_URI")
     abi_dir = os.getenv("ABI_DIR")
 
     arg_dict = {}
-    if artifacts_url is not None:
-        arg_dict["ARTIFACTS_URL"] = artifacts_url
-    if rpc_url is not None:
-        arg_dict["RPC_URL"] = rpc_url
+    if artifacts_uri is not None:
+        arg_dict["ARTIFACTS_URL"] = artifacts_uri
+    if rpc_uri is not None:
+        arg_dict["RPC_URL"] = rpc_uri
     if abi_dir is not None:
         arg_dict["ABI_DIR"] = abi_dir
     return EthConfig(**arg_dict)

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -1,5 +1,5 @@
 """Interfaces for bots and hyperdrive smart contracts."""
-from .addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_url
+from .addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
 from .assets import AssetIdPrefix, decode_asset_id, encode_asset_id
 from .errors import HyperdriveErrors, lookup_hyperdrive_error_selector
 from .get_web3_and_hyperdrive_contracts import get_web3_and_hyperdrive_contracts

--- a/lib/ethpy/ethpy/hyperdrive/addresses.py
+++ b/lib/ethpy/ethpy/hyperdrive/addresses.py
@@ -22,16 +22,16 @@ class HyperdriveAddresses:
     mock_hyperdrive_math: Address | ChecksumAddress | None = attr.ib()
 
 
-def fetch_hyperdrive_address_from_url(contracts_url: str) -> HyperdriveAddresses:
+def fetch_hyperdrive_address_from_uri(contracts_uri: str) -> HyperdriveAddresses:
     """Fetch addresses for deployed contracts in the Hyperdrive system."""
     response = None
     for _ in range(100):
-        response = requests.get(contracts_url, timeout=60)
+        response = requests.get(contracts_uri, timeout=60)
         # Check the status code and retry the request if it fails
         if response.status_code != 200:
             logging.warning(
-                "Request for contracts_url=%s failed with status code %s @ %s",
-                contracts_url,
+                "Request for contracts_uri=%s failed with status code %s @ %s",
+                contracts_uri,
                 response.status_code,
                 time.ctime(),
             )

--- a/lib/ethpy/ethpy/hyperdrive/get_web3_and_hyperdrive_contracts.py
+++ b/lib/ethpy/ethpy/hyperdrive/get_web3_and_hyperdrive_contracts.py
@@ -8,7 +8,7 @@ from ethpy.base import initialize_web3_with_http_provider, load_all_abis
 from web3 import Web3
 from web3.contract.contract import Contract
 
-from .addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_url
+from .addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
 
 
 def get_web3_and_hyperdrive_contracts(
@@ -19,7 +19,7 @@ def get_web3_and_hyperdrive_contracts(
     Arguments
     ---------
     eth_config: EthConfig
-        Configuration for urls to the rpc and artifacts.
+        Configuration for URIs to the rpc and artifacts.
     contract_addresses: HyperdriveAddresses | None
         Configuration for defining various contract addresses.
         Will query eth_config artifacts for addresses by default
@@ -34,12 +34,12 @@ def get_web3_and_hyperdrive_contracts(
     """
     # Initialize contract addresses if none
     if contract_addresses is None:
-        contract_addresses = fetch_hyperdrive_address_from_url(os.path.join(eth_config.ARTIFACTS_URL, "addresses.json"))
+        contract_addresses = fetch_hyperdrive_address_from_uri(os.path.join(eth_config.artifacts_uri, "addresses.json"))
 
     # point to chain env
-    web3 = initialize_web3_with_http_provider(eth_config.RPC_URL, reset_provider=False)
+    web3 = initialize_web3_with_http_provider(eth_config.rpc_uri, reset_provider=False)
     # setup base contract interface
-    abis = load_all_abis(eth_config.ABI_DIR)
+    abis = load_all_abis(eth_config.abi_dir)
     # set up the ERC20 contract for minting base tokens
     # TODO is there a better way to pass in base and hyperdrive abi?
     base_token_contract: Contract = web3.eth.contract(

--- a/lib/ethpy/ethpy/test_fixtures/deploy_hyperdrive.py
+++ b/lib/ethpy/ethpy/test_fixtures/deploy_hyperdrive.py
@@ -62,13 +62,13 @@ def initialize_deploy_account(web3: Web3) -> LocalAccount:
     return account
 
 
-def deploy_hyperdrive_factory(rpc_url: str, deploy_account: LocalAccount) -> tuple[Contract, Contract]:
-    """Deploys the hyperdrive factory contract on the rpc_url chain
+def deploy_hyperdrive_factory(rpc_uri: str, deploy_account: LocalAccount) -> tuple[Contract, Contract]:
+    """Deploys the hyperdrive factory contract on the rpc_uri chain.
 
     Arguments
     ---------
-    rpc_url: str
-        The RPC URL of the chain
+    rpc_uri: str
+        The RPC URI of the chain
     deploy_account: LocalAccount
         The account that deploys the contracts
 
@@ -92,7 +92,7 @@ def deploy_hyperdrive_factory(rpc_url: str, deploy_account: LocalAccount) -> tup
 
     # Load compiled objects
     abis, bytecodes = load_all_abis(abi_folder, return_bytecode=True)
-    web3 = initialize_web3_with_http_provider(rpc_url, reset_provider=False)
+    web3 = initialize_web3_with_http_provider(rpc_uri, reset_provider=False)
     # Convert deploy address to checksum address
     deploy_account_addr = Web3.to_checksum_address(deploy_account.address)
 

--- a/lib/ethpy/ethpy/test_fixtures/local_chain.py
+++ b/lib/ethpy/ethpy/test_fixtures/local_chain.py
@@ -24,7 +24,7 @@ def local_chain() -> Iterator[str]:
     Returns
     -------
     Iterator[str]
-        Yields the local anvil chain url
+        Yields the local anvil chain URI
     """
     anvil_port = 9999
     host = "127.0.0.1"  # localhost
@@ -68,7 +68,7 @@ def local_hyperdrive_chain(local_chain: str) -> LocalHyperdriveChain:
     Arguments
     ---------
     local_chain: str
-        The `local_chain` test fixture that binds to the local anvil chain rpc url
+        The `local_chain` test fixture that binds to the local anvil chain rpc URI
 
     Returns
     -------

--- a/tests/bot_to_db_test.py
+++ b/tests/bot_to_db_test.py
@@ -51,7 +51,7 @@ class TestBotToDb:
         """
         # Get hyperdrive chain info
         uri: URI | None = cast(HTTPProvider, local_hyperdrive_chain.web3.provider).endpoint_uri
-        rpc_url = uri if uri else URI("http://localhost:8545")
+        rpc_uri = uri if uri else URI("http://localhost:8545")
         deploy_account: LocalAccount = local_hyperdrive_chain.deploy_account
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_chain.hyperdrive_contract_addresses
 
@@ -83,9 +83,9 @@ class TestBotToDb:
 
         # Build custom eth config pointing to local test chain
         eth_config = EthConfig(
-            # Artifacts_url isn't used here, as we explicitly set addresses and passed to run_bots
-            ARTIFACTS_URL="not_used",
-            RPC_URL=rpc_url,
+            # Artifacts_uri isn't used here, as we explicitly set addresses and passed to run_bots
+            artifacts_uri="not_used",
+            rpc_uri=rpc_uri,
             # Using default abi dir
         )
 


### PR DESCRIPTION
Web3 uses the term "URI" instead of "URL", so this PR renames our variables to be consistent. The two terms are actually [not the same](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier). A URL is a type of URI that specifies the asset (also known as a URN) and resource (for example, `http://`). Since we may not need to specify a resource, we use the more general "URI" term.

99% of the time we will be providing a URL and the distinction is all but pedantic. It only starts to matter if we say e.g. `my_url: URI = URI("address")` -- this is immediately contradictory, which occurs when we are creating variables that have the web3py `URI` type.