### PR TITLE
pypechain support for functions with multiple signatures

### DIFF
--- a/lib/pypechain/pypechain/run_pypechain.py
+++ b/lib/pypechain/pypechain/run_pypechain.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 from dataclasses import asdict
 from pathlib import Path
@@ -64,8 +65,8 @@ def format_code(code: str, line_length: int) -> str:
     str
         A string containing the Black-formatted code
     """
-    while "\n\n" in code:
-        code = code.replace("\n\n", "\n")  # remove extra newlines and let Black sort it out
+    while "\n\n" in code:  # remove extra newlines and let Black sort it out
+        code = re.sub(r"^[\s\t]*\n", "", code, flags=re.MULTILINE)
     code = code.replace(", )", ")")  # remove trailing comma
     try:
         return black.format_file_contents(code, fast=False, mode=black.Mode(line_length=line_length))

--- a/lib/pypechain/pypechain/run_pypechain.py
+++ b/lib/pypechain/pypechain/run_pypechain.py
@@ -65,8 +65,8 @@ def format_code(code: str, line_length: int) -> str:
     str
         A string containing the Black-formatted code
     """
-    while "\n\n" in code:  # remove extra newlines and let Black sort it out
-        code = re.sub(r"^[\s\t]*\n", "", code, flags=re.MULTILINE)
+    # remove extra newlines and let Black sort it out
+    code = re.sub(r"^[\s\t]*\n\n", "\n", code, flags=re.MULTILINE)
     code = code.replace(", )", ")")  # remove trailing comma
     try:
         return black.format_file_contents(code, fast=False, mode=black.Mode(line_length=line_length))
@@ -305,9 +305,11 @@ def get_outputs(function: ABIFunction) -> list[str]:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print("Usage: python script_name.py <path_to_abi_file> <contract_address> <output_dir>")
-    else:
-        # TODO: add a bash script to make this easier, i.e. ./pypechain './abis', './build'
-        # TODO: make this installable so that other packages can use the command line tool
+    # TODO: add a bash script to make this easier, i.e. ./pypechain './abis', './build'
+    # TODO: make this installable so that other packages can use the command line tool
+    if len(sys.argv) == 3:
         main(sys.argv[1], sys.argv[2])
+    elif len(sys.argv) == 4:
+        main(sys.argv[1], sys.argv[2], int(sys.argv[3]))
+    else:
+        print("Usage: python script_name.py <path_to_abi_file> <output_dir> <line_length>")

--- a/lib/pypechain/pypechain/run_pypechain.py
+++ b/lib/pypechain/pypechain/run_pypechain.py
@@ -22,6 +22,33 @@ from pypechain.utilities.types import solidity_to_python_type
 from web3.types import ABIFunction
 
 
+def get_intersection_and_unique(lists: list[list[str]]) -> tuple[set[str], set[str]]:
+    """Process a list of lists of strings to get the intersection and unique values.
+
+    The intersection is a set of strings that occur in all sub-lists.
+    The unique values are strings that only occur in one sub-list.
+
+    Arguments
+    ---------
+    lists : list[list[str]]
+        A list of lists of strings, where each sub-list is an entity to compute sets over.
+
+    Returns
+    -------
+    tuple[set[str], set[str]]
+        The (intersection, unique_values) sets
+    """
+    intersection = set(lists[0])
+    for lst in lists[1:]:
+        intersection &= set(lst)
+    string_counts = {}
+    for lst in lists:
+        for item in set(lst):
+            string_counts[item] = string_counts.get(item, 0) + 1
+    unique_values = {item for item, count in string_counts.items() if count == 1}
+    return (intersection, unique_values)
+
+
 def format_code(code: str, line_length: int) -> str:
     """Format code with Black on default settings.
 
@@ -47,7 +74,7 @@ def format_code(code: str, line_length: int) -> str:
 
 
 def write_code(path: str | os.PathLike, code: str) -> None:
-    """save to specified path the provided code.
+    """Save to specified path the provided code.
 
     Arguments
     ---------
@@ -116,25 +143,43 @@ def render_contract_file(contract_name: str, contract_template: Template, abi_fi
 
     # TODO:  return types to function calls
     # Extract function names and their input parameters from the ABI
-    abi_functions_and_events = get_abi_items(abi_file_path)
-
-    function_datas = []
-    for abi_function in abi_functions_and_events:
+    function_datas = {}
+    for abi_function in get_abi_items(abi_file_path):
         if is_abi_function(abi_function):
             # TODO: investigate better typing here?  templete.render expects an object so we'll have to convert.
             name = abi_function.get("name", "")
-            function_data = {
-                # TODO: pass a typeguarded ABIFunction that has only required fields?
-                # name is required in the typeguard.  Should be safe to default to empty string.
-                "name": name,
-                "capitalized_name": capitalize_first_letter_only(name),
-                "input_names_and_types": get_input_names_and_values(abi_function),
-                "input_names": get_input_names(abi_function),
-                "outputs": get_outputs(abi_function),
-            }
-            function_datas.append(function_data)
+            if name not in function_datas:
+                function_data = {
+                    # TODO: pass a typeguarded ABIFunction that has only required fields?
+                    # name is required in the typeguard.  Should be safe to default to empty string.
+                    "name": name,
+                    "capitalized_name": capitalize_first_letter_only(name),
+                    "input_names_and_types": [get_input_names_and_values(abi_function)],
+                    "input_names": [get_input_names(abi_function)],
+                    "outputs": [get_outputs(abi_function)],
+                }
+                function_datas[name] = function_data
+            else:  # this function already exists, presumably with a different signature
+                function_datas[name]["input_names_and_types"].append(get_input_names_and_values(abi_function))
+                function_datas[name]["input_names"].append(get_input_names(abi_function))
+                function_datas[name]["outputs"].append(get_outputs(abi_function))
+                # input_names_and_types will need optional args at the end
+                shared_input_names_and_types, unique_input_names_and_types = get_intersection_and_unique(
+                    function_datas[name]["input_names_and_types"]
+                )
+                function_datas[name]["required_input_names_and_types"] = shared_input_names_and_types
+                function_datas[name]["optional_input_names_and_types"] = []
+                for name_and_type in unique_input_names_and_types:  # optional args
+                    name_and_type += " | None = None"
+                    function_datas[name]["optional_input_names_and_types"].append(name_and_type)
+                # we will also need the names to be separated
+                shared_input_names, unique_input_names = get_intersection_and_unique(
+                    function_datas[name]["input_names"]
+                )
+                function_datas[name]["required_input_names"] = shared_input_names
+                function_datas[name]["optional_input_names"] = unique_input_names
     # Render the template
-    return contract_template.render(contract_name=contract_name, functions=function_datas)
+    return contract_template.render(contract_name=contract_name, functions=list(function_datas.values()))
 
 
 def render_types_file(contract_name: str, types_template: Template, abi_file_path: Path) -> str:
@@ -184,7 +229,6 @@ def get_input_names_and_values(function: ABIFunction) -> list[str]:
     list[str]
         A list of function names and corresponding python values, i.e. ['arg1: str', 'arg2: bool']
     """
-
     stringified_function_parameters: list[str] = []
     for _input in function.get("inputs", []):
         if name := get_param_name(_input):
@@ -196,9 +240,12 @@ def get_input_names_and_values(function: ABIFunction) -> list[str]:
 
 
 def stringify_parameters(parameters) -> list[str]:
-    # TODO: handle empty strings.  Should replace them with 'arg1', 'arg2', and so one.
-    # TODO: recursively handle this too for evil nested tuples with no names.
-    """Stringifies parameters."""
+    """Stringifies parameters.
+
+    .. todo::
+        handle empty strings.  Should replace them with 'arg1', 'arg2', and so one.
+        recursively handle this too for evil nested tuples with no names.
+    """
     stringified_function_parameters: list[str] = []
     arg_counter: int = 1
     for _input in parameters:
@@ -228,7 +275,6 @@ def get_input_names(function: ABIFunction) -> list[str]:
     -------
     list[str]
         A list of function names i.e. ['arg1', 'arg2']
-
     """
     return stringify_parameters(function.get("inputs", []))
 

--- a/lib/pypechain/pypechain/run_pypechain.py
+++ b/lib/pypechain/pypechain/run_pypechain.py
@@ -137,6 +137,8 @@ def render_types_file(contract_name: str, types_template: Template, abi_file_pat
 
     Arguments
     ---------
+    contract_name : str
+        The name of the contract to be parsed.
     types_template : Template
         A jinja template containging types for all structs within an abi.
     abi_file_path : Path

--- a/lib/pypechain/pypechain/run_pypechain.py
+++ b/lib/pypechain/pypechain/run_pypechain.py
@@ -38,16 +38,24 @@ def format_code(code: str, line_length: int) -> str:
         A string containing the Black-formatted code
     """
     while "\n\n" in code:
-        code = code.replace("\n\n", "\n")  # remove all whitespace and let Black sort it out
-    code = code.replace(", )", ")")  # remove trailing comma, it's weird
+        code = code.replace("\n\n", "\n")  # remove extra newlines and let Black sort it out
+    code = code.replace(", )", ")")  # remove trailing comma
     try:
         return black.format_file_contents(code, fast=False, mode=black.Mode(line_length=line_length))
     except ValueError as exc:
         raise ValueError(f"cannot format with Black\n code:\n{code}") from exc
 
 
-def write_code(path, code):
-    """save to specified path the provided code."""
+def write_code(path: str | os.PathLike, code: str) -> None:
+    """save to specified path the provided code.
+
+    Arguments
+    ---------
+    path : str | os.PathLike
+        The location of the output file.
+    code : str
+        The code to be written, as a single string.
+    """
     with open(path, "w", encoding="utf-8") as output_file:
         output_file.write(code)
 
@@ -59,13 +67,10 @@ def main(abi_file_path: str, output_dir: str, line_length: int = 80) -> None:
     ---------
     abi_file_path : str
         Path to the abi JSON file.
-    output_dir : str
-        Path to where the Python files should go.
+    output_dr: str
+        Path to the directory where files will be generated.
     line_length : int
         Optional argument for the output file's maximum line length. Defaults to 80.
-
-    output_dr: str
-        Path to the directory to output the generated files.
     """
 
     # get names

--- a/lib/pypechain/pypechain/templates/contract.jinja2
+++ b/lib/pypechain/pypechain/templates/contract.jinja2
@@ -11,7 +11,6 @@ from web3.exceptions import FallbackNotFound
 {% for function in functions %}
 class {{contract_name}}{{function.capitalized_name}}ContractFunction(ContractFunction):
     """ContractFunction for the {{function.name}} method."""
-    # pylint: disable=arguments-differ
     {# functions with multiple signatures have a more complicated logic #}
     {% if function.input_names_and_types|length > 1 %} 
     def __call__(self, {{function.required_input_names_and_types|join(', ')}}, {{function.optional_input_names_and_types|join(', ')}}) -> "{{contract_name}}{{function.capitalized_name}}ContractFunction":

--- a/lib/pypechain/pypechain/templates/contract.jinja2
+++ b/lib/pypechain/pypechain/templates/contract.jinja2
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, cast
+
 from eth_typing import ChecksumAddress
 from web3.contract.contract import Contract, ContractFunction, ContractFunctions
 from web3.exceptions import FallbackNotFound

--- a/lib/pypechain/pypechain/templates/contract.jinja2
+++ b/lib/pypechain/pypechain/templates/contract.jinja2
@@ -7,17 +7,66 @@ from eth_typing import ChecksumAddress
 from web3.contract.contract import Contract, ContractFunction, ContractFunctions
 from web3.exceptions import FallbackNotFound
 
+{# loop over all functions and create types for each #}
 {% for function in functions %}
 class {{contract_name}}{{function.capitalized_name}}ContractFunction(ContractFunction):
     """ContractFunction for the {{function.name}} method."""
-
     # pylint: disable=arguments-differ
-    def __call__(self, {{function.input_names_and_types|join(', ')}}) -> "{{contract_name}}{{function.capitalized_name}}ContractFunction":
-        super().__call__({{function.input_names|join(', ')}})
+    {# functions with multiple signatures have a more complicated logic #}
+    {% if function.input_names_and_types|length > 1 %} 
+    def __call__(self, {{function.required_input_names_and_types|join(', ')}}, {{function.optional_input_names_and_types|join(', ')}}) -> "{{contract_name}}{{function.capitalized_name}}ContractFunction":
+        {# loop over the signatures for this function #}
+        {% for signature_names in function.input_names %}
+        {# determine what type of python condition this will be #}
+        {% if loop.first %}
+        {% set conditional_string = 'if' %}
+        {% elif loop.last %}
+        {% set conditional_string = 'else' %}
+        {% else %}
+        {% set conditional_string = 'elif' %}
+        {% endif %}
+        {# python "if" or "elif" condition #}
+        {% if conditional_string != 'else' %}
+        {# get the optional names that are in in this signature #}
+        {%- set optional_names_in_this_signature = signature_names|select('in', function.optional_input_names)|list %}
+        {# does this signature have no optional names? #}
+        {% if optional_names_in_this_signature|length == 0 %}
+        {# py: [if] all optional args are None, execute this signature #}
+        {{conditional_string}} all([{{function.optional_input_names|join(' is None, ')}} is None]):
+        {# does this signature have optional names? #}
+        {% else %}
+        {# get the optional names that are not in this signature #}
+        {%- set optional_names_not_in_this_signature = function.optional_input_names|reject('in', signature_names)|list %}
+        {# does this signature have all of the optional names? #}
+        {% if  optional_names_not_in_this_signature|length == 0 %}
+        {# py: [if] all optional args are not None, execute this signature #}
+        {{conditional_string}} all([{{optional_names_in_this_signature|join(' is not None, ')}} is not None]):
+        {# are there optional names not in this signature? #}
+        {% else %}
+        {# py: [if] all optional signature args are not None and others are None, execute this signature #}
+        {{conditional_string}} (
+            all([{{optional_names_in_this_signature|join(' is not None, ')}} is not None])
+            and
+            all([{{optional_names_not_in_this_signature|join(' is None, ')}} is None])
+        ):
+        {% endif %}
+        {% endif %}
+        {# if we are the "else" python condition, don't check any values in python #}
+        {% else %}
+        {{conditional_string}}:
+        {% endif %}
+            super().__call__({{signature_names|join(', ')}})
+            return self
+        {% endfor %}
+    {# for functions with only one signature, just make the super call #}
+    {% else %}
+    def __call__(self, {{function.input_names_and_types[0]|join(', ')}}) -> "{{contract_name}}{{function.capitalized_name}}ContractFunction":
+        super().__call__({{function.input_names[0]|join(', ')}})
         return self
+    {% endif %}
+
     # TODO: add call def so we can get return types for the calls
     # def call()
-
 {% endfor %}
 
 

--- a/lib/pypechain/pypechain/templates/types.jinja2
+++ b/lib/pypechain/pypechain/templates/types.jinja2
@@ -1,9 +1,10 @@
 #pylint: disable=invalid-name
 """Dataclasses for all structs in the {{contract_name}} contract."""
-
-from web3.types import ABIEvent, ABIEventParams
+from __future__ import annotations
 
 from dataclasses import dataclass
+
+from web3.types import ABIEvent, ABIEventParams
 
 {% for struct in structs %}
 @dataclass

--- a/lib/pypechain/pypechain/utilities/abi.py
+++ b/lib/pypechain/pypechain/utilities/abi.py
@@ -165,7 +165,7 @@ class EventParams:
 # pylint: disable=dangerous-default-value
 def get_structs(
     function_params: Sequence[ABIFunctionParams] | Sequence[ABIFunctionComponents],
-    structs: dict[str, StructInfo] = {},
+    structs: dict[str, StructInfo] | None = None,
 ) -> dict[str, StructInfo]:
     """Recursively gets all the structs for a contract by walking all function parameters.
 
@@ -209,7 +209,8 @@ def get_structs(
     List[Union[ABIFunction, ABIEvent]]
         _description_
     """
-
+    if structs is None:
+        structs = {}
     for param in function_params:
         components = param.get("components")
         internal_type = cast(str, param.get("internalType", ""))
@@ -263,11 +264,10 @@ def get_structs_for_abi(abi: ABI) -> dict[str, StructInfo]:
             fn_outputs = item.get("outputs")
             if fn_inputs:
                 input_structs = get_structs(fn_inputs)
-                structs.update(input_structs)
+                structs.update(input_structs, structs)
             if fn_outputs:
                 output_structs = get_structs(fn_outputs)
-                structs.update(output_structs)
-
+                structs.update(output_structs, structs)
     return structs
 
 

--- a/lib/pypechain/pypechain/utilities/abi.py
+++ b/lib/pypechain/pypechain/utilities/abi.py
@@ -263,11 +263,11 @@ def get_structs_for_abi(abi: ABI) -> dict[str, StructInfo]:
             fn_inputs = item.get("inputs")
             fn_outputs = item.get("outputs")
             if fn_inputs:
-                input_structs = get_structs(fn_inputs)
-                structs.update(input_structs, structs)
+                input_structs = get_structs(fn_inputs, structs)
+                structs.update(input_structs)
             if fn_outputs:
-                output_structs = get_structs(fn_outputs)
-                structs.update(output_structs, structs)
+                output_structs = get_structs(fn_outputs, structs)
+                structs.update(output_structs)
     return structs
 
 

--- a/lib/pypechain/pypechain/utilities/abi.py
+++ b/lib/pypechain/pypechain/utilities/abi.py
@@ -161,8 +161,6 @@ class EventParams:
     python_type: str
 
 
-# This is a recursive function, need to initialize with an empty dict.
-# pylint: disable=dangerous-default-value
 def get_structs(
     function_params: Sequence[ABIFunctionParams] | Sequence[ABIFunctionComponents],
     structs: dict[str, StructInfo] | None = None,
@@ -245,7 +243,8 @@ def get_structs(
 
 
 def get_structs_for_abi(abi: ABI) -> dict[str, StructInfo]:
-    """Gets all the structs for a given abi. These are found by parsing function inputs and outputs for internalType's.
+    """Gets all the structs for a given abi.
+    These are found by parsing function inputs and outputs for internalType's.
 
     Arguments
     ---------
@@ -389,7 +388,7 @@ def load_abi_from_file(file_path: Path) -> ABI:
 
 
 def get_abi_items(file_path: Path) -> list[ABIElement]:
-    """Gets all the
+    """Gets all of the functions and events in the ABI.
 
     Arguments
     ---------
@@ -402,8 +401,8 @@ def get_abi_items(file_path: Path) -> list[ABIElement]:
         _description_
     """
 
-    web3 = Web3()
     abi = load_abi_from_file(file_path)
+    web3 = Web3()
     contract = web3.eth.contract(abi=abi)
 
     # leverage the private list of ABIFunction's

--- a/lib/pypechain/pyproject.toml
+++ b/lib/pypechain/pyproject.toml
@@ -17,12 +17,9 @@ classifiers = [
 
 [project.optional-dependencies]
 # This flag installs all dependencies and should be ran when installing this subpackage in isolation
-with-dependencies = ["pypechain[base]"]
-base = ["jinja2", "web3"]
-lateral = [
-    # Lateral dependencies across subpackages are pointing to github
-    "ethpy @ git+https://github.com/delvtech/elf-simulations.git/#subdirectory=lib/ethpy",
-]
+with-dependencies = ["pypechain[base, lateral]"]
+base = ["black", "jinja2", "web3"]
+lateral = []
 
 [project.urls]
 "Homepage" = "https://github.com/delvtech/elf-simulations"


### PR DESCRIPTION
A single contract function can have multiple signatures, which is not supported in Python.
For example, before this PR pypechain would produce something like this:
```
class my_class:
   def __init__(arg0: type0, arg1: type1):
       ... # do stuff for condition 0

class my_class:
    def __init__(arg1: type1):
        ... # do stuff for condition 1
```

We need to use optional arguments to support this in Python. For example:
```
class my_class
    def __init__(arg1: type1, arg0: type0 | None = None):
        if arg0 is None:
            ... # do stuff for condition 1
        else:
            ... # do stuff for condition 0
```


To work this out, here is the new template logic: 
```
loop over the signatures for this function 
  does this signature include any optional arguments?
  no:
    py: if all optionals are None, execute this signature
  yes:
    optional_args_in_sig = the optional arguments required by this signature
    optional_args_not_in_sig = optional arguments that are not present in this signature.
    are all of the optional arguments in this signature?
    yes:
      py: if sig_optional_args are not None, execute this signature
    no:
      py: if sig_optional_args are not None AND other_optional_args are None, execute this signature
```

I had to modify the output from run_pypechain.py to get that conditional to work.

I also fixed an ABI bug where a variable holding the dictionary of structs was persisting across multiple calls to `pypechain::run_pypechain::main`.

Smaller stuff: fixed lint errors, added docs, added type hints, fixed install dependencies, improved functionality with black