### PR TITLE
Fixing race condition for analysis

### DIFF
--- a/lib/agent0/agent0/accounts_config.py
+++ b/lib/agent0/agent0/accounts_config.py
@@ -112,7 +112,6 @@ def initialize_accounts(
     else:
         logging.info("Loading %s", env_file)
         # Ensure account_config matches up with env_file
-        # TODO this is where we would read state of agent from chain
         account_key_config = build_account_config_from_env(env_file)
         num_total_agents = sum(agent.number_of_agents for agent in agent_config)
         if num_total_agents != len(account_key_config.AGENT_KEYS):

--- a/lib/agent0/agent0/hyperdrive/exec/run_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/run_agents.py
@@ -166,7 +166,6 @@ def build_wallet_positions_from_data(
         withdraw_obj = FixedPoint(0)
     else:
         withdraw_obj = FixedPoint(withdraw_balances.iloc[0]["value"])
-    # TODO Build withdraw share object
 
     return HyperdriveWallet(
         address=HexBytes(wallet_addr),

--- a/lib/chainsync/chainsync/db/hyperdrive/__init__.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/__init__.py
@@ -21,6 +21,7 @@ from .interface import (
     get_current_wallet_info,
     get_latest_block_number_from_analysis_table,
     get_latest_block_number_from_pool_info_table,
+    get_latest_block_number_from_table,
     get_pool_analysis,
     get_pool_config,
     get_pool_info,

--- a/lib/chainsync/chainsync/exec/data_analysis.py
+++ b/lib/chainsync/chainsync/exec/data_analysis.py
@@ -8,8 +8,11 @@ import time
 from chainsync.analysis import data_to_analysis
 from chainsync.db.base import initialize_session
 from chainsync.db.hyperdrive import (
+    HyperdriveTransaction,
+    PoolInfo,
+    WalletDelta,
     get_latest_block_number_from_analysis_table,
-    get_latest_block_number_from_pool_info_table,
+    get_latest_block_number_from_table,
     get_pool_config,
 )
 from ethpy import EthConfig, build_eth_config
@@ -79,6 +82,8 @@ def data_analysis(
         pool_config_len = len(pool_config_df)
         if pool_config_len == 0:
             time.sleep(_SLEEP_AMOUNT)
+        else:
+            break
     if pool_config_df is None:
         raise ValueError("Error in getting pool config from db")
     assert len(pool_config_df) == 1
@@ -88,7 +93,7 @@ def data_analysis(
     # monitor for new blocks & add pool info per block
     logging.info("Monitoring database for updates...")
     while True:
-        latest_data_block_number = get_latest_block_number_from_pool_info_table(db_session)
+        latest_data_block_number = get_latest_data_block(db_session)
         # Only execute if we are on a new block
         if latest_data_block_number <= block_number:
             time.sleep(_SLEEP_AMOUNT)
@@ -103,3 +108,22 @@ def data_analysis(
         data_to_analysis(analysis_start_block, analysis_end_block, pool_config, db_session, hyperdrive_contract)
         block_number = latest_data_block_number
         time.sleep(_SLEEP_AMOUNT)
+
+
+def get_latest_data_block(db_session: Session):
+    """Gets the latest block the data pipeline has written
+    Since there are multiple tables that analysis reads from,
+    we query the latest block from all read tables and select the minimum
+    block from the list
+
+    Arguments
+    ---------
+    db_session: Session
+        Session object for connecting to db.
+    """
+
+    latest_pool_info = get_latest_block_number_from_table(PoolInfo, db_session)
+    latest_wallet_delta = get_latest_block_number_from_table(WalletDelta, db_session)
+    latest_transactions = get_latest_block_number_from_table(HyperdriveTransaction, db_session)
+
+    return min(latest_pool_info, latest_wallet_delta, latest_transactions)

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -5,6 +5,7 @@ from .assets import AssetIdPrefix, decode_asset_id, encode_asset_id
 from .errors import HyperdriveErrors, lookup_hyperdrive_error_selector
 from .get_web3_and_hyperdrive_contracts import get_web3_and_hyperdrive_contracts
 from .interface import (
+    get_event_history_from_chain,
     get_hyperdrive_checkpoint,
     get_hyperdrive_market,
     get_hyperdrive_pool_config,

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -467,7 +467,7 @@ class HyperdriveInterface:
         """
         # for now, assume an underlying vault share price of at least 1, should be higher by a bit
         agent_checksum_address = Web3.to_checksum_address(agent.address)
-        min_output = FixedPoint(1)
+        min_output = FixedPoint(scaled_value=1)
         as_underlying = True
         fn_args = (trade_amount.scaled_value, min_output.scaled_value, agent_checksum_address, as_underlying)
         tx_receipt = await async_smart_contract_transact(

--- a/lib/ethpy/ethpy/hyperdrive/interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface.py
@@ -322,3 +322,88 @@ def parse_logs(tx_receipt: TxReceipt, hyperdrive_contract: Contract, fn_name: st
     if "withdrawalShareAmount" in log_args:
         trade_result.withdrawal_share_amount = FixedPoint(scaled_value=log_args["withdrawalShareAmount"])
     return trade_result
+
+
+def get_event_history_from_chain(
+    hyperdrive_contract: Contract, from_block: int, to_block: int, wallet_addr: str | None = None
+) -> dict:
+    """Helper function to query event logs directly from the chain.
+    Useful for debugging open positions of wallet addresses.
+    This might be creating unnecessary filters if ran, so only use for debugging
+
+    Arguments
+    ---------
+    hyperdrive_contract : Contract
+        The deployed hyperdrive contract instance.
+    from_block: int
+        The starting block to query
+    to_block: int
+        The end block to query. If from_block == to_block, will query the specified block number
+    wallet_addr: str | None
+        The wallet address to filter events on. If None, will return all.
+
+    Returns
+    -------
+    A dictionary of event logs, keyed by the event name. Specifically:
+        # TODO figure out return type of web3 call
+        "addLiquidity": list[Unknown]
+        "removeLiquidity": list[Unknown]
+        "redeemWithdrawalShares": list[Unknown]
+        "openLong": list[Unknown]
+        "closeLong": list[Unknown]
+        "openShort": list[Unknown]
+        "closeShort": list[Unknown]
+        "total_events": int
+    """
+
+    # Build arguments
+    lp_addr_filter = {}
+    trade_addr_filter = {}
+    if wallet_addr is not None:
+        lp_addr_filter = {"provider": wallet_addr}
+        trade_addr_filter = {"trader": wallet_addr}
+    lp_filter_args = {"fromBlock": from_block, "toBlock": to_block, "argument_filters": lp_addr_filter}
+    trade_filter_args = {"fromBlock": from_block, "toBlock": to_block, "argument_filters": trade_addr_filter}
+
+    # Create filter on events
+    # Typing doesn't know about create_filter function with various events
+    add_lp_event_filter = hyperdrive_contract.events.AddLiquidity.create_filter(**lp_filter_args)  # type: ignore
+    remove_lp_event_filter = hyperdrive_contract.events.RemoveLiquidity.create_filter(**lp_filter_args)  # type:ignore
+    withdraw_event_filter = hyperdrive_contract.events.RedeemWithdrawalShares.create_filter(  # type:ignore
+        **lp_filter_args
+    )
+    open_long_event_filter = hyperdrive_contract.events.OpenLong.create_filter(**trade_filter_args)  # type:ignore
+    close_long_event_filter = hyperdrive_contract.events.CloseLong.create_filter(**trade_filter_args)  # type:ignore
+    open_short_event_filter = hyperdrive_contract.events.OpenShort.create_filter(**trade_filter_args)  # type:ignore
+    close_short_event_filter = hyperdrive_contract.events.CloseShort.create_filter(**trade_filter_args)  # type:ignore
+
+    # Retrieve all entries
+    add_lp_events = add_lp_event_filter.get_all_entries()
+    remove_lp_events = remove_lp_event_filter.get_all_entries()
+    withdraw_events = withdraw_event_filter.get_all_entries()
+    open_long_events = open_long_event_filter.get_all_entries()
+    close_long_events = close_long_event_filter.get_all_entries()
+    open_short_events = open_short_event_filter.get_all_entries()
+    close_short_events = close_short_event_filter.get_all_entries()
+
+    # Calculate total events on chain
+    total_events = (
+        len(add_lp_events)
+        + len(remove_lp_events)
+        + len(withdraw_events)
+        + len(open_long_events)
+        + len(close_long_events)
+        + len(open_short_events)
+        + len(close_short_events)
+    )
+
+    return {
+        "addLiquidity": add_lp_events,
+        "removeLiquidity": remove_lp_events,
+        "redeemWithdrawalShares": withdraw_events,
+        "openLong": open_long_events,
+        "closeLong": close_long_events,
+        "openShort": open_short_events,
+        "closeShort": close_short_events,
+        "total_events": total_events,
+    }

--- a/lib/ethpy/ethpy/hyperdrive/interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface.py
@@ -355,6 +355,8 @@ def get_event_history_from_chain(
         "closeShort": list[Unknown]
         "total_events": int
     """
+    # TODO clean up this function
+    # pylint: disable=too-many-locals
 
     # Build arguments
     lp_addr_filter = {}


### PR DESCRIPTION
Analysis script had a race condition with the data collection script. Specifically, if the analysis script queried data from a block after pool_info was written, but before transactions and wallet deltas was written, the analysis script would potentially miss transactions.

Also adding in helper function useful for debugging to gather and filter hyperdrive events directly from the chain.