### PR TITLE
Anaylsis batch hotfix

### DIFF
--- a/lib/chainsync/chainsync/db/hyperdrive/__init__.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/__init__.py
@@ -5,7 +5,6 @@ from .convert_data import (
     convert_hyperdrive_transactions_for_block,
     convert_pool_config,
     convert_pool_info,
-    get_wallet_info,
 )
 from .interface import (
     add_checkpoint_infos,
@@ -13,12 +12,9 @@ from .interface import (
     add_pool_infos,
     add_transactions,
     add_wallet_deltas,
-    add_wallet_infos,
     get_all_traders,
-    get_all_wallet_info,
     get_checkpoint_info,
     get_current_wallet,
-    get_current_wallet_info,
     get_latest_block_number_from_analysis_table,
     get_latest_block_number_from_pool_info_table,
     get_latest_block_number_from_table,
@@ -29,7 +25,6 @@ from .interface import (
     get_total_wallet_pnl_over_time,
     get_transactions,
     get_wallet_deltas,
-    get_wallet_info_history,
     get_wallet_pnl,
     get_wallet_positions_over_time,
 )
@@ -42,6 +37,5 @@ from .schema import (
     PoolInfo,
     Ticker,
     WalletDelta,
-    WalletInfoFromChain,
     WalletPNL,
 )

--- a/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
@@ -21,16 +21,8 @@ from .convert_data import (
     convert_hyperdrive_transactions_for_block,
     convert_pool_config,
     convert_pool_info,
-    get_wallet_info,
 )
-from .interface import (
-    add_checkpoint_infos,
-    add_pool_config,
-    add_pool_infos,
-    add_transactions,
-    add_wallet_deltas,
-    add_wallet_infos,
-)
+from .interface import add_checkpoint_infos, add_pool_config, add_pool_infos, add_transactions, add_wallet_deltas
 
 _RETRY_COUNT = 10
 _RETRY_SLEEP_SECONDS = 1
@@ -130,21 +122,3 @@ def data_chain_to_db(
         raise ValueError("Error in getting transactions")
     add_transactions(block_transactions, session)
     add_wallet_deltas(wallet_deltas, session)
-
-    # Query and add wallet info
-    # TODO put the wallet info query as an optional block,
-    # and check these wallet values with what we get from the deltas
-    wallet_info_for_transactions = None
-    for _ in range(_RETRY_COUNT):
-        try:
-            wallet_info_for_transactions = get_wallet_info(
-                hyperdrive_contract, base_contract, block_number, block_transactions, block_pool_info
-            )
-            break
-        except ValueError:
-            logging.warning("Error in fetch_contract_transactions_for_block, retrying")
-            time.sleep(_RETRY_SLEEP_SECONDS)
-            continue
-    if wallet_info_for_transactions is None:
-        raise ValueError("Error in getting wallet_info")
-    add_wallet_infos(wallet_info_for_transactions, session)

--- a/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
@@ -55,7 +55,6 @@ def init_data_chain_to_db(
 
 def data_chain_to_db(
     web3: Web3,
-    base_contract: Contract,
     hyperdrive_contract: Contract,
     block_number: BlockNumber,
     session: Session,

--- a/lib/chainsync/chainsync/db/hyperdrive/schema.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema.py
@@ -81,27 +81,6 @@ class PoolInfo(Base):
     totalSupplyWithdrawalShares: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
 
 
-# TODO: Rename this to something more accurate to what is happening, e.g. HyperdriveTransactions
-# TODO deprecate this schema
-class WalletInfoFromChain(Base):
-    """Table/dataclass schema for wallet information."""
-
-    __tablename__ = "wallet_info_from_chain"
-
-    # Default table primary key
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False, autoincrement=True)
-    blockNumber: Mapped[int] = mapped_column(BigInteger, index=True)
-    walletAddress: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
-    # baseTokenType can be BASE, LONG, SHORT, LP, or WITHDRAWAL_SHARE
-    baseTokenType: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
-    # tokenType is the baseTokenType appended with "-<maturity_time>" for LONG and SHORT
-    tokenType: Mapped[Union[str, None]] = mapped_column(String, default=None)
-    tokenValue: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
-    # While time here is in epoch seconds, we use Numeric to allow for (1) lossless storage and (2) allow for NaNs
-    maturityTime: Mapped[Union[int, None]] = mapped_column(Numeric, default=None)
-    sharePrice: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
-
-
 # TODO: either make a more general TokenDelta, or rename this to HyperdriveDelta
 class WalletDelta(Base):
     """Table/dataclass schema for wallet deltas."""

--- a/lib/chainsync/chainsync/db/hyperdrive/schema_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema_test.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from decimal import Decimal
 
-from .schema import CheckpointInfo, HyperdriveTransaction, PoolConfig, PoolInfo, WalletDelta, WalletInfoFromChain
+from .schema import CheckpointInfo, HyperdriveTransaction, PoolConfig, PoolInfo, WalletDelta
 
 # These tests are using fixtures defined in conftest.py
 
@@ -191,38 +191,3 @@ class TestWalletDeltaTable:
         db_session.commit()
         deleted_wallet_delta = db_session.query(WalletDelta).filter_by(blockNumber=1).first()
         assert deleted_wallet_delta is None
-
-
-class TestWalletInfoTable:
-    """CRUD tests for WalletInfo table"""
-
-    def test_create_wallet_info(self, db_session):
-        """Create and entry"""
-        wallet_info = WalletInfoFromChain(blockNumber=1, tokenValue=Decimal("3.2"))
-        db_session.add(wallet_info)
-        db_session.commit()
-        retrieved_wallet_info = db_session.query(WalletInfoFromChain).filter_by(blockNumber=1).first()
-        assert retrieved_wallet_info is not None
-        # tokenValue retrieved from postgres is in Decimal, cast to float
-        assert float(retrieved_wallet_info.tokenValue) == 3.2
-
-    def test_update_wallet_info(self, db_session):
-        """Update an entry"""
-        wallet_info = WalletInfoFromChain(blockNumber=1, tokenValue=Decimal("3.2"))
-        db_session.add(wallet_info)
-        db_session.commit()
-        wallet_info.tokenValue = Decimal("5.0")
-        db_session.commit()
-        updated_wallet_info = db_session.query(WalletInfoFromChain).filter_by(blockNumber=1).first()
-        # tokenValue retrieved from postgres is in Decimal, cast to float
-        assert float(updated_wallet_info.tokenValue) == 5.0
-
-    def test_delete_wallet_info(self, db_session):
-        """Delete an entry"""
-        wallet_info = WalletInfoFromChain(blockNumber=1, tokenValue=Decimal("3.2"))
-        db_session.add(wallet_info)
-        db_session.commit()
-        db_session.delete(wallet_info)
-        db_session.commit()
-        deleted_wallet_info = db_session.query(WalletInfoFromChain).filter_by(blockNumber=1).first()
-        assert deleted_wallet_info is None

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -67,7 +67,7 @@ def acquire_data(
         contract_addresses = fetch_hyperdrive_address_from_uri(os.path.join(eth_config.artifacts_uri, "addresses.json"))
 
     # Get web3 and contracts
-    web3, base_contract, hyperdrive_contract = get_web3_and_hyperdrive_contracts(eth_config, contract_addresses)
+    web3, _, hyperdrive_contract = get_web3_and_hyperdrive_contracts(eth_config, contract_addresses)
 
     ## Get starting point for restarts
     # Get last entry of pool info in db
@@ -88,7 +88,7 @@ def acquire_data(
     # This if statement executes only on initial run (based on data_latest_block_number check),
     # and if the chain has executed until start_block (based on latest_mined_block check)
     if data_latest_block_number < block_number < latest_mined_block:
-        data_chain_to_db(web3, base_contract, hyperdrive_contract, block_number, db_session)
+        data_chain_to_db(web3, hyperdrive_contract, block_number, db_session)
 
     # Main data loop
     # monitor for new blocks & add pool info per block
@@ -118,5 +118,5 @@ def acquire_data(
                     latest_mined_block,
                 )
                 continue
-            data_chain_to_db(web3, base_contract, hyperdrive_contract, block_number, db_session)
+            data_chain_to_db(web3, hyperdrive_contract, block_number, db_session)
         time.sleep(_SLEEP_AMOUNT)

--- a/lib/chainsync/chainsync/exec/data_analysis.py
+++ b/lib/chainsync/chainsync/exec/data_analysis.py
@@ -122,8 +122,7 @@ def get_latest_data_block(db_session: Session):
         Session object for connecting to db.
     """
 
+    # Note to avoid race condition, we add pool info as the last update for the block
     latest_pool_info = get_latest_block_number_from_table(PoolInfo, db_session)
-    latest_wallet_delta = get_latest_block_number_from_table(WalletDelta, db_session)
-    latest_transactions = get_latest_block_number_from_table(HyperdriveTransaction, db_session)
 
-    return min(latest_pool_info, latest_wallet_delta, latest_transactions)
+    return latest_pool_info

--- a/lib/chainsync/chainsync/exec/data_analysis.py
+++ b/lib/chainsync/chainsync/exec/data_analysis.py
@@ -8,9 +8,7 @@ import time
 from chainsync.analysis import data_to_analysis
 from chainsync.db.base import initialize_session
 from chainsync.db.hyperdrive import (
-    HyperdriveTransaction,
     PoolInfo,
-    WalletDelta,
     get_latest_block_number_from_analysis_table,
     get_latest_block_number_from_table,
     get_pool_config,


### PR DESCRIPTION
Previously, we look at the minimum block number of transactions, wallet deltas, and pool info to see the last block updated. However, there's a case where a large number of blocks tick up without any transactions. In this case, the next transaction will result in analysis attempting to process a large number of blocks, which breaks the analysis pipeline.

This PR resolves this issue, along with the race condition solved in https://github.com/delvtech/elf-simulations/pull/906 by ensuring we write pool_info as the last item, and using pool_info as the table to see how far along the data process is.

This also deprecates all current wallet info tables from the db in favor of using wallet deltas, as current wallet info needed pool_info data for its calculations.