### PR TITLE
Funding bots now async with retries

### DIFF
--- a/lib/agent0/agent0/base/config/environment_config.py
+++ b/lib/agent0/agent0/base/config/environment_config.py
@@ -26,7 +26,7 @@ class EnvironmentConfig(FrozenClass):
     # if halt_on_errors is True, halt_on_slippage controls if we halt when slippage happens
     halt_on_slippage: bool = False
     # optional output filename for logging
-    log_filename: str = "agent0-logs"
+    log_filename: str = ".logging/agent0_logs.log"
     # log level; should be in [logging.DEBUG, logging.INFO, logging.WARNING]
     log_level: int = DEFAULT_LOG_LEVEL  # INFO
     # delete_previous_logs; if True, delete existing logs at the start of the run

--- a/lib/agent0/agent0/hyperdrive/exec/__init__.py
+++ b/lib/agent0/agent0/hyperdrive/exec/__init__.py
@@ -5,7 +5,7 @@ from .execute_agent_trades import (
     async_execute_single_agent_trade,
     async_match_contract_call_to_trade,
 )
-from .fund_agents import fund_agents
+from .fund_agents import async_fund_agents
 from .get_agent_accounts import get_agent_accounts
 from .run_agents import run_agents
 from .setup_experiment import setup_experiment

--- a/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
@@ -2,22 +2,25 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 
 from agent0 import AccountKeyConfig
 from agent0.hyperdrive.agents import HyperdriveAgent
+from elfpy.utils import logs as log_utils
 from eth_account.account import Account
 from ethpy import EthConfig
 from ethpy.base import (
     async_eth_transfer,
-    async_retry_call,
     async_smart_contract_transact,
     get_account_balance,
     initialize_web3_with_http_provider,
     load_abi_from_file,
+    retry_call,
     smart_contract_read,
 )
 from ethpy.hyperdrive import HyperdriveAddresses
+from web3.types import Nonce, TxReceipt
 
 RETRY_COUNT = 5
 
@@ -42,6 +45,10 @@ async def async_fund_agents(
     contract_addresses: HyperdriveAddresses
         Configuration for defining various contract addresses.
     """
+
+    # Funding contains its own logging as this is typically ran from a script or in debug mode
+    log_utils.setup_logging(".logging/fund_accounts.log", log_stdout=True)
+
     agent_accounts = [
         HyperdriveAgent(Account().from_key(agent_private_key)) for agent_private_key in account_key_config.AGENT_KEYS
     ]
@@ -82,33 +89,95 @@ async def async_fund_agents(
         )
 
     # Launch all funding processes in async mode
-    print("Funding accounts")
 
     # Sanity check for zip function
     assert len(agent_accounts) == len(account_key_config.AGENT_ETH_BUDGETS)
     assert len(agent_accounts) == len(account_key_config.AGENT_BASE_BUDGETS)
 
-    # Gather all async function calls in a list
-    # Running with retries
-    eth_funding_calls = [
-        async_retry_call(
-            RETRY_COUNT, None, async_eth_transfer, web3, user_account, agent_account.checksum_address, agent_eth_budget
-        )
-        for agent_account, agent_eth_budget in zip(agent_accounts, account_key_config.AGENT_ETH_BUDGETS)
+    # We launch funding in batches, so we do an outer retry loop here
+    # Fund eth
+    logging.info("Funding Eth")
+    accounts_left = [
+        (agent_account, eth_budget)
+        for agent_account, eth_budget in zip(agent_accounts, account_key_config.AGENT_ETH_BUDGETS)
     ]
-    base_funding_calls = [
-        async_retry_call(
-            RETRY_COUNT,
-            None,
-            async_smart_contract_transact,
-            web3,
-            base_token_contract,
-            user_account,
-            "transfer",
-            agent_account.checksum_address,
-            agent_base_budget,
-        )
-        for agent_account, agent_base_budget in zip(agent_accounts, account_key_config.AGENT_BASE_BUDGETS)
-    ]
+    for attempt in range(RETRY_COUNT):
+        # Fund agents async from a single account.
+        # To do this, we need to manually set the nonce, so we get the base transaction count here
+        # and pass in an incrementing nonce per call
+        # TODO figure out which exception here to retry on
+        base_nonce = retry_call(5, None, web3.eth.get_transaction_count, user_account.checksum_address)
 
-    await asyncio.gather(*(eth_funding_calls + base_funding_calls))
+        # Gather all async function calls in a list
+        # Running with retries
+        # Explicitly setting a nonce here due to nonce issues with launching a batch of transactions
+        eth_funding_calls = [
+            async_eth_transfer(
+                web3, user_account, agent_account.checksum_address, agent_eth_budget, nonce=Nonce(base_nonce + i)
+            )
+            for i, (agent_account, agent_eth_budget) in enumerate(accounts_left)
+        ]
+        gather_results: list[TxReceipt | Exception] = await asyncio.gather(*eth_funding_calls, return_exceptions=True)
+
+        # Rebuild accounts_left list if the result errored out for next iteration
+        accounts_left = []
+        for account, result in zip(accounts_left, gather_results):
+            if isinstance(result, Exception):
+                accounts_left.append(account)
+                logging.warning(
+                    "Retry attempt %s out of %s: Eth transfer failed with exception %s",
+                    attempt,
+                    RETRY_COUNT,
+                    repr(result),
+                )
+        # If all accounts funded, break retry loop
+        if len(accounts_left) == 0:
+            break
+
+    # We launch funding in batches, so we do an outer retry loop here
+    # Fund base
+    logging.info("Funding Base")
+    accounts_left = [
+        (agent_account, base_budget)
+        for agent_account, base_budget in zip(agent_accounts, account_key_config.AGENT_BASE_BUDGETS)
+    ]
+    for attempt in range(RETRY_COUNT):
+        # Fund agents async from a single account.
+        # To do this, we need to manually set the nonce, so we get the base transaction count here
+        # and pass in an incrementing nonce per call
+        # TODO figure out which exception here to retry on
+        base_nonce = retry_call(5, None, web3.eth.get_transaction_count, user_account.checksum_address)
+
+        # Gather all async function calls in a list
+        # Running with retries
+        # Explicitly setting a nonce here due to nonce issues with launching a batch of transactions
+        base_funding_calls = [
+            async_smart_contract_transact(
+                web3,
+                base_token_contract,
+                user_account,
+                "transfer",
+                agent_account.checksum_address,
+                agent_base_budget,
+                nonce=Nonce(base_nonce + i),
+            )
+            for i, (agent_account, agent_base_budget) in enumerate(accounts_left)
+        ]
+        gather_results: list[TxReceipt | Exception] = await asyncio.gather(*base_funding_calls, return_exceptions=True)
+
+        # Rebuild accounts_left list if the result errored out for next iteration
+        accounts_left = []
+        for account, result in zip(accounts_left, gather_results):
+            if isinstance(result, Exception):
+                accounts_left.append(account)
+                logging.warning(
+                    "Retry attempt %s out of %s: Base transfer failed with exception %s",
+                    attempt,
+                    RETRY_COUNT,
+                    repr(result),
+                )
+        # If all accounts funded, break retry loop
+        if len(accounts_left) == 0:
+            break
+
+    logging.info("Accounts funded")

--- a/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
@@ -21,9 +21,6 @@ from ethpy.hyperdrive import HyperdriveAddresses
 
 RETRY_COUNT = 5
 
-# TODO async_retry_call should really be a generic util function, not something in
-# ethpy to be used here.
-
 
 async def async_fund_agents(
     user_account: HyperdriveAgent,
@@ -88,8 +85,8 @@ async def async_fund_agents(
     print("Funding accounts")
 
     # Sanity check for zip function
-    assert len(agent_accounts) == account_key_config.AGENT_ETH_BUDGETS
-    assert len(agent_accounts) == account_key_config.AGENT_BASE_BUDGETS
+    assert len(agent_accounts) == len(account_key_config.AGENT_ETH_BUDGETS)
+    assert len(agent_accounts) == len(account_key_config.AGENT_BASE_BUDGETS)
 
     # Gather all async function calls in a list
     # Running with retries

--- a/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
@@ -48,7 +48,7 @@ async def async_fund_agents(
         Configuration for defining various contract addresses.
     """
 
-    # Funding contains its own logging as this is typically ran from a script or in debug mode
+    # Funding contains its own logging as this is typically run from a script or in debug mode
     log_utils.setup_logging(".logging/fund_accounts.log", log_stdout=True, delete_previous_logs=True)
 
     agent_accounts = [

--- a/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
@@ -49,7 +49,7 @@ async def async_fund_agents(
     """
 
     # Funding contains its own logging as this is typically ran from a script or in debug mode
-    log_utils.setup_logging(".logging/fund_accounts.log", log_stdout=True)
+    log_utils.setup_logging(".logging/fund_accounts.log", log_stdout=True, delete_previous_logs=True)
 
     agent_accounts = [
         HyperdriveAgent(Account().from_key(agent_private_key)) for agent_private_key in account_key_config.AGENT_KEYS

--- a/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
@@ -1,6 +1,7 @@
 """Fund agent private keys from a user key."""
 from __future__ import annotations
 
+import asyncio
 import os
 
 from agent0 import AccountKeyConfig
@@ -8,17 +9,23 @@ from agent0.hyperdrive.agents import HyperdriveAgent
 from eth_account.account import Account
 from ethpy import EthConfig
 from ethpy.base import (
-    eth_transfer,
+    async_eth_transfer,
+    async_retry_call,
+    async_smart_contract_transact,
     get_account_balance,
     initialize_web3_with_http_provider,
     load_abi_from_file,
     smart_contract_read,
-    smart_contract_transact,
 )
 from ethpy.hyperdrive import HyperdriveAddresses
 
+RETRY_COUNT = 5
 
-def fund_agents(
+# TODO async_retry_call should really be a generic util function, not something in
+# ethpy to be used here.
+
+
+async def async_fund_agents(
     user_account: HyperdriveAgent,
     eth_config: EthConfig,
     account_key_config: AccountKeyConfig,
@@ -53,37 +60,50 @@ def fund_agents(
         abi=base_contract_abi, address=web3.to_checksum_address(contract_addresses.base_token)
     )
 
-    for agent_account, agent_eth_budget, agent_base_budget in zip(
-        agent_accounts, account_key_config.AGENT_ETH_BUDGETS, account_key_config.AGENT_BASE_BUDGETS
-    ):
-        print(f"Funding account {agent_account.checksum_address}")
-        # fund Ethereum
-        user_eth_balance = get_account_balance(web3, user_account.checksum_address)
-        if user_eth_balance is None:
-            raise AssertionError("User has no Ethereum balance")
-        if user_eth_balance < agent_eth_budget:
-            raise AssertionError(
-                f"User account {user_account.checksum_address=} has {user_eth_balance=}, "
-                f"which must be >= {agent_eth_budget=}"
-            )
-        _ = eth_transfer(
-            web3,
-            user_account,
-            agent_account.checksum_address,
-            agent_eth_budget,
+    # Check for balances
+    total_agent_eth_budget = sum((int(budget) for budget in account_key_config.AGENT_ETH_BUDGETS))
+    total_agent_base_budget = sum((int(budget) for budget in account_key_config.AGENT_BASE_BUDGETS))
+
+    user_eth_balance = get_account_balance(web3, user_account.checksum_address)
+    if user_eth_balance is None:
+        raise AssertionError("User has no Ethereum balance")
+    if user_eth_balance < total_agent_eth_budget:
+        raise AssertionError(
+            f"User account {user_account.checksum_address=} has {user_eth_balance=}, "
+            f"which must be >= {total_agent_eth_budget=}"
         )
-        #  fund base
-        user_base_balance = smart_contract_read(
-            base_token_contract,
-            "balanceOf",
-            user_account.checksum_address,
-        )["value"]
-        if user_base_balance < agent_base_budget:
-            raise AssertionError(
-                f"User account {user_account.checksum_address=} has {user_base_balance=}, "
-                f"which must be >= {agent_base_budget=}"
-            )
-        _ = smart_contract_transact(
+
+    user_base_balance = smart_contract_read(
+        base_token_contract,
+        "balanceOf",
+        user_account.checksum_address,
+    )["value"]
+    if user_base_balance < total_agent_base_budget:
+        raise AssertionError(
+            f"User account {user_account.checksum_address=} has {user_base_balance=}, "
+            f"which must be >= {total_agent_base_budget=}"
+        )
+
+    # Launch all funding processes in async mode
+    print("Funding accounts")
+
+    # Sanity check for zip function
+    assert len(agent_accounts) == account_key_config.AGENT_ETH_BUDGETS
+    assert len(agent_accounts) == account_key_config.AGENT_BASE_BUDGETS
+
+    # Gather all async function calls in a list
+    # Running with retries
+    eth_funding_calls = [
+        async_retry_call(
+            RETRY_COUNT, None, async_eth_transfer, web3, user_account, agent_account.checksum_address, agent_eth_budget
+        )
+        for agent_account, agent_eth_budget in zip(agent_accounts, account_key_config.AGENT_ETH_BUDGETS)
+    ]
+    base_funding_calls = [
+        async_retry_call(
+            RETRY_COUNT,
+            None,
+            async_smart_contract_transact,
             web3,
             base_token_contract,
             user_account,
@@ -91,3 +111,7 @@ def fund_agents(
             agent_account.checksum_address,
             agent_base_budget,
         )
+        for agent_account, agent_base_budget in zip(agent_accounts, account_key_config.AGENT_BASE_BUDGETS)
+    ]
+
+    await asyncio.gather(*(eth_funding_calls + base_funding_calls))

--- a/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
@@ -25,6 +25,8 @@ from web3.types import Nonce, TxReceipt
 RETRY_COUNT = 5
 
 
+# TODO break up this function
+# pylint: disable=too-many-locals
 async def async_fund_agents(
     user_account: HyperdriveAgent,
     eth_config: EthConfig,
@@ -97,10 +99,8 @@ async def async_fund_agents(
     # We launch funding in batches, so we do an outer retry loop here
     # Fund eth
     logging.info("Funding Eth")
-    accounts_left = [
-        (agent_account, eth_budget)
-        for agent_account, eth_budget in zip(agent_accounts, account_key_config.AGENT_ETH_BUDGETS)
-    ]
+    # Prepare accounts and eth budgets
+    accounts_left = list(zip(agent_accounts, account_key_config.AGENT_ETH_BUDGETS))
     for attempt in range(RETRY_COUNT):
         # Fund agents async from a single account.
         # To do this, we need to manually set the nonce, so we get the base transaction count here
@@ -137,10 +137,8 @@ async def async_fund_agents(
     # We launch funding in batches, so we do an outer retry loop here
     # Fund base
     logging.info("Funding Base")
-    accounts_left = [
-        (agent_account, base_budget)
-        for agent_account, base_budget in zip(agent_accounts, account_key_config.AGENT_BASE_BUDGETS)
-    ]
+    # Prepare accounts and eth budgets
+    accounts_left = list(zip(agent_accounts, account_key_config.AGENT_BASE_BUDGETS))
     for attempt in range(RETRY_COUNT):
         # Fund agents async from a single account.
         # To do this, we need to manually set the nonce, so we get the base transaction count here

--- a/lib/agent0/agent0/hyperdrive/exec/get_agent_accounts.py
+++ b/lib/agent0/agent0/hyperdrive/exec/get_agent_accounts.py
@@ -108,7 +108,7 @@ async def set_max_approval(
         The address of the deployed hyperdrive contract
     """
 
-    agents_left = [agent for agent in agents]
+    agents_left = list(agents)
     for attempt in range(RETRY_COUNT):
         approval_calls = [
             async_smart_contract_transact(

--- a/lib/agent0/agent0/hyperdrive/exec/get_agent_accounts.py
+++ b/lib/agent0/agent0/hyperdrive/exec/get_agent_accounts.py
@@ -1,6 +1,7 @@
 """Script for loading ETH & Elfpy agents with trading policies"""
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import eth_utils
@@ -8,11 +9,14 @@ from agent0 import AccountKeyConfig
 from agent0.base.config import AgentConfig
 from agent0.hyperdrive.agents import HyperdriveAgent
 from eth_account.account import Account
-from ethpy.base import get_account_balance, smart_contract_read, smart_contract_transact
+from ethpy.base import async_smart_contract_transact, get_account_balance, smart_contract_read
 from fixedpointmath import FixedPoint
 from numpy.random._generator import Generator as NumpyGenerator
 from web3 import Web3
 from web3.contract.contract import Contract
+from web3.types import TxReceipt
+
+RETRY_COUNT = 5
 
 
 # TODO consolidate various configs into one config?
@@ -77,16 +81,59 @@ def get_agent_accounts(
             agent_base_funds = smart_contract_read(base_token_contract, "balanceOf", eth_agent.checksum_address)
             if agent_base_funds["value"] == 0:
                 raise AssertionError("Agent needs Base tokens to operate! Did you fund their accounts?")
-            # establish max approval for the hyperdrive contract
-            _ = smart_contract_transact(
+            agents.append(eth_agent)
+        num_agents_so_far.append(agent_info.number_of_agents)
+    logging.info("Added %d agents", sum(num_agents_so_far))
+
+    # establish max approval for the hyperdrive contract
+    asyncio.run(set_max_approval(agents, web3, base_token_contract, hyperdrive_address))
+
+    return agents
+
+
+async def set_max_approval(
+    agents: list[HyperdriveAgent], web3: Web3, base_token_contract: Contract, hyperdrive_address: str
+) -> None:
+    """Establish max approval for the hyperdrive contract for all agents async
+
+    Arguments
+    ---------
+    agents : list[HyperdriveAgent]
+        List of agents
+    web3 : Web3
+        web3 provider object
+    base_token_contract : Contract
+        The deployed ERC20 base token contract
+    hyperdrive_address : str
+        The address of the deployed hyperdrive contract
+    """
+
+    agents_left = [agent for agent in agents]
+    for attempt in range(RETRY_COUNT):
+        approval_calls = [
+            async_smart_contract_transact(
                 web3,
                 base_token_contract,
-                eth_agent,
+                agent,
                 "approve",
                 hyperdrive_address,
                 eth_utils.conversions.to_int(eth_utils.currency.MAX_WEI),
             )
-            agents.append(eth_agent)
-        num_agents_so_far.append(agent_info.number_of_agents)
-    logging.info("Added %d agents", sum(num_agents_so_far))
-    return agents
+            for agent in agents_left
+        ]
+        gather_results: list[TxReceipt | Exception] = await asyncio.gather(*approval_calls, return_exceptions=True)
+
+        # Rebuild accounts_left list if the result errored out for next iteration
+        agents_left = []
+        for agent, result in zip(agents_left, gather_results):
+            if isinstance(result, Exception):
+                agents_left.append(agent)
+                logging.warning(
+                    "Retry attempt %s out of %s: Base approval failed with exception %s",
+                    attempt,
+                    RETRY_COUNT,
+                    repr(result),
+                )
+        # If successful, break retry loop
+        if len(agents_left) == 0:
+            break

--- a/lib/agent0/agent0/hyperdrive/exec/run_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/run_agents.py
@@ -1,6 +1,7 @@
 """Runner script for agents"""
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import warnings
@@ -20,7 +21,7 @@ from hexbytes import HexBytes
 from web3.contract.contract import Contract
 
 from .create_and_fund_user_account import create_and_fund_user_account
-from .fund_agents import fund_agents
+from .fund_agents import async_fund_agents
 from .setup_experiment import setup_experiment
 from .trade_loop import trade_if_new_block
 
@@ -78,8 +79,8 @@ def run_agents(
     if develop:
         # exposing the user account for debugging purposes
         user_account = create_and_fund_user_account(eth_config, account_key_config, contract_addresses)
-        fund_agents(
-            user_account, eth_config, account_key_config, contract_addresses
+        asyncio.run(
+            async_fund_agents(user_account, eth_config, account_key_config, contract_addresses)
         )  # uses env variables created above as inputs
     # get hyperdrive interface object and agents
     hyperdrive, agent_accounts = setup_experiment(

--- a/lib/agent0/bin/fund_agents_from_user_key.py
+++ b/lib/agent0/bin/fund_agents_from_user_key.py
@@ -1,12 +1,13 @@
 """Helper script to generate a random private key."""
 
 import argparse
+import asyncio
 import logging
 import os
 
 from agent0 import build_account_config_from_env
 from agent0.hyperdrive.agents import HyperdriveAgent
-from agent0.hyperdrive.exec import fund_agents
+from agent0.hyperdrive.exec import async_fund_agents
 from eth_account.account import Account
 from ethpy import EthConfig
 from ethpy.hyperdrive import fetch_hyperdrive_address_from_uri
@@ -50,7 +51,7 @@ if __name__ == "__main__":
     contract_addresses = fetch_hyperdrive_address_from_uri(os.path.join(eth_config.artifacts_uri, "addresses.json"))
     user_account = HyperdriveAgent(Account().from_key(account_key_config.USER_KEY))
 
-    fund_agents(user_account, eth_config, account_key_config, contract_addresses)
+    asyncio.run(async_fund_agents(user_account, eth_config, account_key_config, contract_addresses))
 
     # User key could have been passed in here, rewrite the accounts env file
     if user_key is not None:

--- a/lib/agent0/examples/custom_agent.py
+++ b/lib/agent0/examples/custom_agent.py
@@ -190,7 +190,7 @@ eth_config = EthConfig(artifacts_uri="http://" + HOST + ":8080", rpc_uri="http:/
 env_config = EnvironmentConfig(
     delete_previous_logs=False,
     halt_on_errors=True,
-    log_filename="agent0-logs",
+    log_filename=".logging/agent0_logs.logs",
     log_level=logging.INFO,
     log_stdout=True,
     random_seed=1234,

--- a/lib/agent0/examples/hyperdrive_agents.py
+++ b/lib/agent0/examples/hyperdrive_agents.py
@@ -23,7 +23,7 @@ LIQUIDATE = False
 eth_config = EthConfig(artifacts_uri="http://" + HOST + ":8080", rpc_uri="http://" + HOST + ":8545")
 
 env_config = EnvironmentConfig(
-    delete_previous_logs=False,
+    delete_previous_logs=True,
     halt_on_errors=True,
     log_filename=".logging/agent0_logs.log",
     log_level=logging.INFO,

--- a/lib/agent0/examples/hyperdrive_agents.py
+++ b/lib/agent0/examples/hyperdrive_agents.py
@@ -25,7 +25,7 @@ eth_config = EthConfig(artifacts_uri="http://" + HOST + ":8080", rpc_uri="http:/
 env_config = EnvironmentConfig(
     delete_previous_logs=False,
     halt_on_errors=True,
-    log_filename="agent0-logs",
+    log_filename=".logging/agent0_logs.log",
     log_level=logging.INFO,
     log_stdout=True,
     random_seed=1234,

--- a/lib/chainsync/bin/update_usernames.py
+++ b/lib/chainsync/bin/update_usernames.py
@@ -62,7 +62,7 @@ username_to_user = {
 # This reads the .env file for database credentials
 db_session = initialize_session()
 
-log_utils.setup_logging(".logging/update_usernames.log", log_stdout=True)
+log_utils.setup_logging(".logging/update_usernames.log", log_stdout=True, delete_previous_logs=True)
 
 # Add to database
 for addr, username in addr_to_username.items():

--- a/lib/ethpy/ethpy/base/__init__.py
+++ b/lib/ethpy/ethpy/base/__init__.py
@@ -11,6 +11,7 @@ from .transactions import (
     async_wait_for_transaction_receipt,
     eth_transfer,
     fetch_contract_transactions_for_block,
+    retry_call,
     smart_contract_preview_transaction,
     smart_contract_read,
     smart_contract_transact,

--- a/lib/ethpy/ethpy/base/__init__.py
+++ b/lib/ethpy/ethpy/base/__init__.py
@@ -3,15 +3,14 @@ from .abi import load_abi_from_file, load_all_abis
 from .api import BaseInterface
 from .errors import ABIError, UnknownBlockError, decode_error_selector_for_contract
 from .receipts import get_event_object, get_transaction_logs
+from .retry_utils import async_retry_call, retry_call
 from .rpc_interface import get_account_balance, set_anvil_account_balance
 from .transactions import (
     async_eth_transfer,
-    async_retry_call,
     async_smart_contract_transact,
     async_wait_for_transaction_receipt,
     eth_transfer,
     fetch_contract_transactions_for_block,
-    retry_call,
     smart_contract_preview_transaction,
     smart_contract_read,
     smart_contract_transact,

--- a/lib/ethpy/ethpy/base/__init__.py
+++ b/lib/ethpy/ethpy/base/__init__.py
@@ -5,6 +5,8 @@ from .errors import ABIError, UnknownBlockError, decode_error_selector_for_contr
 from .receipts import get_event_object, get_transaction_logs
 from .rpc_interface import get_account_balance, set_anvil_account_balance
 from .transactions import (
+    async_eth_transfer,
+    async_retry_call,
     async_smart_contract_transact,
     async_wait_for_transaction_receipt,
     eth_transfer,

--- a/lib/ethpy/ethpy/base/retry_utils.py
+++ b/lib/ethpy/ethpy/base/retry_utils.py
@@ -1,0 +1,125 @@
+"""Wrapper functions for retrying"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import time
+from typing import Awaitable, Callable, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+async def async_retry_call(
+    retry_count: int,
+    retry_exception_check: Callable[[Exception], bool] | None,
+    func: Callable[P, Awaitable[R]],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> R:
+    """Helper function to retry an async function call
+
+    Arguments
+    ---------
+    retry_count: int
+        The number of times to retry the function
+    retry_exception_check: Callable[[type[Exception]], bool] | None
+        A function that takes as an argument an exception and returns True if we want to retry on that exception
+        If None, will retry for all exceptions
+    func: Callable[P, Awaitable[R]]
+        The function to call.
+    *args: P.args
+        The positional arguments to call func with
+    **kwargs: P.kwargs
+        The keyword arguments to call the func with
+
+    Returns
+    -------
+    R
+        Returns the value of the called function
+    """
+    # TODO can't make a default for `retry_exception_check` due to *args and **kwargs,
+    # so we need to explicitly pass in this parameter
+    exception = None
+    for attempt_number in range(retry_count):
+        try:
+            out = await func(*args, **kwargs)
+            return out
+        # Catching general exception but throwing if fails
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            # Raise exception immediately if exception check fails
+            if retry_exception_check is not None and not retry_exception_check(exc):
+                raise exc
+            # Get caller of this function's name
+            caller = inspect.stack()[1][3]
+            logging.warning(
+                "Retry attempt %s out of %s: Function %s called from %s failed with %s",
+                attempt_number,
+                retry_count,
+                func,
+                caller,
+                repr(exc),
+            )
+            exception = exc
+            # TODO implement smarter wait here
+            await asyncio.sleep(0.1)
+    assert exception is not None
+    raise exception
+
+
+def retry_call(
+    retry_count: int,
+    retry_exception_check: Callable[[Exception], bool] | None,
+    func: Callable[P, R],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> R:
+    """Helper function to retry a function call
+
+    Arguments
+    ---------
+    retry_count: int
+        The number of times to retry the function
+    retry_exception_check: Callable[[type[Exception]], bool] | None
+        A function that takes as an argument an exception and returns True if we want to retry on that exception
+        If None, will retry for all exceptions
+    func: Callable[P, Awaitable[R]]
+        The function to call
+    *args: P.args
+        The positional arguments to call func with
+    **kwargs: P.kwargs
+        The keyword arguments to call the func with
+
+    Returns
+    -------
+    R
+        Returns the value of the called function
+    """
+    # TODO can't make a default for `retry_exception_check` due to *args and **kwargs,
+    # so we need to explicitly pass in this parameter
+    exception = None
+    for attempt_number in range(retry_count):
+        try:
+            out = func(*args, **kwargs)
+            return out
+        # Catching general exception but throwing if fails
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            # Raise exception immediately if exception check fails
+            if retry_exception_check is not None and not retry_exception_check(exc):
+                raise exc
+            # Get caller of this function's name
+            caller = inspect.stack()[1][3]
+            logging.warning(
+                "Retry attempt %s out of %s: Function %s called from %s failed with %s",
+                attempt_number,
+                retry_count,
+                func,
+                caller,
+                repr(exc),
+            )
+            exception = exc
+            # TODO implement smarter wait here
+            time.sleep(0.1)
+    assert exception is not None
+    raise exception

--- a/lib/ethpy/ethpy/base/transactions.py
+++ b/lib/ethpy/ethpy/base/transactions.py
@@ -1,11 +1,8 @@
 """Web3 powered functions for interfacing with smart contracts"""
 from __future__ import annotations
 
-import asyncio
-import inspect
 import logging
-import time
-from typing import Any, Awaitable, Callable, ParamSpec, Sequence, TypeVar
+from typing import Any, Sequence
 
 from eth_account.signers.local import LocalAccount
 from eth_typing import BlockNumber, ChecksumAddress
@@ -24,6 +21,7 @@ from web3.exceptions import (
 from web3.types import ABI, ABIFunctionComponents, ABIFunctionParams, BlockData, Nonce, TxData, TxParams, TxReceipt, Wei
 
 from .errors.errors import decode_error_selector_for_contract
+from .retry_utils import retry_call
 
 # TODO these should be parameterized so the caller controls how many times to retry
 READ_RETRY_COUNT = 5
@@ -32,123 +30,6 @@ READ_RETRY_COUNT = 5
 # Currently catching write when status=0, but ideally this would be a specific
 # "anvil is breaking" error. We're currently disabling by setting WRITE_RETRY_COUNT to 1.
 WRITE_RETRY_COUNT = 1
-
-P = ParamSpec("P")
-R = TypeVar("R")
-
-
-async def async_retry_call(
-    retry_count: int,
-    retry_exception_check: Callable[[Exception], bool] | None,
-    func: Callable[P, Awaitable[R]],
-    *args: P.args,
-    **kwargs: P.kwargs,
-) -> R:
-    """Helper function to retry an async function call
-
-    Arguments
-    ---------
-    retry_count: int
-        The number of times to retry the function
-    retry_exception_check: Callable[[type[Exception]], bool] | None
-        A function that takes as an argument an exception and returns True if we want to retry on that exception
-        If None, will retry for all exceptions
-    func: Callable[P, Awaitable[R]]
-        The function to call.
-    *args: P.args
-        The positional arguments to call func with
-    **kwargs: P.kwargs
-        The keyword arguments to call the func with
-
-    Returns
-    -------
-    R
-        Returns the value of the called function
-    """
-    # TODO can't make a default for `retry_exception_check` due to *args and **kwargs,
-    # so we need to explicitly pass in this parameter
-    exception = None
-    for attempt_number in range(retry_count):
-        try:
-            out = await func(*args, **kwargs)
-            return out
-        # Catching general exception but throwing if fails
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            # Raise exception immediately if exception check fails
-            if retry_exception_check is not None and not retry_exception_check(exc):
-                raise exc
-            # Get caller of this function's name
-            caller = inspect.stack()[1][3]
-            logging.warning(
-                "Retry attempt %s out of %s: Function %s called from %s failed with %s",
-                attempt_number,
-                retry_count,
-                func,
-                caller,
-                repr(exc),
-            )
-            exception = exc
-            # TODO implement smarter wait here
-            await asyncio.sleep(0.1)
-    assert exception is not None
-    raise exception
-
-
-def retry_call(
-    retry_count: int,
-    retry_exception_check: Callable[[Exception], bool] | None,
-    func: Callable[P, R],
-    *args: P.args,
-    **kwargs: P.kwargs,
-) -> R:
-    """Helper function to retry a function call
-
-    Arguments
-    ---------
-    retry_count: int
-        The number of times to retry the function
-    retry_exception_check: Callable[[type[Exception]], bool] | None
-        A function that takes as an argument an exception and returns True if we want to retry on that exception
-        If None, will retry for all exceptions
-    func: Callable[P, Awaitable[R]]
-        The function to call
-    *args: P.args
-        The positional arguments to call func with
-    **kwargs: P.kwargs
-        The keyword arguments to call the func with
-
-    Returns
-    -------
-    R
-        Returns the value of the called function
-    """
-    # TODO can't make a default for `retry_exception_check` due to *args and **kwargs,
-    # so we need to explicitly pass in this parameter
-    exception = None
-    for attempt_number in range(retry_count):
-        try:
-            out = func(*args, **kwargs)
-            return out
-        # Catching general exception but throwing if fails
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            # Raise exception immediately if exception check fails
-            if retry_exception_check is not None and not retry_exception_check(exc):
-                raise exc
-            # Get caller of this function's name
-            caller = inspect.stack()[1][3]
-            logging.warning(
-                "Retry attempt %s out of %s: Function %s called from %s failed with %s",
-                attempt_number,
-                retry_count,
-                func,
-                caller,
-                repr(exc),
-            )
-            exception = exc
-            # TODO implement smarter wait here
-            time.sleep(0.1)
-    assert exception is not None
-    raise exception
 
 
 def smart_contract_read(contract: Contract, function_name_or_signature: str, *fn_args, **fn_kwargs) -> dict[str, Any]:

--- a/lib/ethpy/ethpy/base/transactions.py
+++ b/lib/ethpy/ethpy/base/transactions.py
@@ -602,7 +602,7 @@ def fetch_contract_transactions_for_block(web3: Web3, contract: Contract, block_
     all_transactions = block.get("transactions")
 
     if not all_transactions:
-        logging.info("no transactions in block %s", block.get("number"))
+        logging.debug("no transactions in block %s", block.get("number"))
         return []
     contract_transactions: list[TxData] = []
     for transaction in all_transactions:

--- a/lib/ethpy/ethpy/base/transactions.py
+++ b/lib/ethpy/ethpy/base/transactions.py
@@ -6,7 +6,6 @@ from typing import Any, Sequence
 
 from eth_account.signers.local import LocalAccount
 from eth_typing import BlockNumber, ChecksumAddress
-from ethpy.base import UnknownBlockError
 from hexbytes import HexBytes
 from web3 import Web3
 from web3._utils.threads import Timeout
@@ -21,6 +20,7 @@ from web3.exceptions import (
 from web3.types import ABI, ABIFunctionComponents, ABIFunctionParams, BlockData, Nonce, TxData, TxParams, TxReceipt, Wei
 
 from .errors.errors import decode_error_selector_for_contract
+from .errors.types import UnknownBlockError
 from .retry_utils import retry_call
 
 # TODO these should be parameterized so the caller controls how many times to retry

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -335,6 +335,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "openLong")
         return trade_result
 
+    # pylint: disable=too-many-arguments
     async def async_close_long(
         self,
         agent: LocalAccount,
@@ -457,6 +458,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "openShort")
         return trade_result
 
+    # pylint: disable=too-many-arguments
     async def async_close_short(
         self,
         agent: LocalAccount,
@@ -517,6 +519,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "closeShort")
         return trade_result
 
+    # pylint: disable=too-many-arguments
     async def async_add_liquidity(
         self,
         agent: LocalAccount,

--- a/lib/ethpy/ethpy/hyperdrive/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api.py
@@ -24,7 +24,7 @@ from fixedpointmath import FixedPoint
 from pyperdrive.types import Fees, PoolConfig, PoolInfo
 from web3 import Web3
 from web3.contract.contract import Contract
-from web3.types import BlockData, Timestamp
+from web3.types import BlockData, Nonce, Timestamp
 
 from .addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
 from .interface import (
@@ -278,6 +278,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
         agent: LocalAccount,
         trade_amount: FixedPoint,
         slippage_tolerance: FixedPoint | None = None,
+        nonce: Nonce | None = None,
     ) -> ReceiptBreakdown:
         """Contract call to open a long position.
 
@@ -291,6 +292,8 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
             Amount of slippage allowed from the trade.
             If None, then execute the trade regardless of the slippage.
             If not None, then the trade will not execute unless the slippage is below this value.
+        nonce: Nonce | None
+            An optional explicit nonce to set with the transaction
 
         Returns
         -------
@@ -327,7 +330,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
                 as_underlying,
             )
         tx_receipt = await async_smart_contract_transact(
-            self.web3, self.hyperdrive_contract, agent, "openLong", *fn_args
+            self.web3, self.hyperdrive_contract, agent, "openLong", *fn_args, nonce=nonce
         )
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "openLong")
         return trade_result
@@ -338,6 +341,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
         trade_amount: FixedPoint,
         maturity_time: int,
         slippage_tolerance: FixedPoint | None = None,
+        nonce: Nonce | None = None,
     ) -> ReceiptBreakdown:
         """Contract call to close a long position.
 
@@ -353,6 +357,8 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
             Amount of slippage allowed from the trade.
             If None, then execute the trade regardless of the slippage.
             If not None, then the trade will not execute unless the slippage is below this value.
+        nonce: Nonce | None
+            An optional explicit nonce to set with the transaction
 
         Returns
         -------
@@ -384,7 +390,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
                 as_underlying,
             )
         tx_receipt = await async_smart_contract_transact(
-            self.web3, self.hyperdrive_contract, agent, "closeLong", *fn_args
+            self.web3, self.hyperdrive_contract, agent, "closeLong", *fn_args, nonce=nonce
         )
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "closeLong")
         return trade_result
@@ -394,6 +400,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
         agent: LocalAccount,
         trade_amount: FixedPoint,
         slippage_tolerance: FixedPoint | None = None,
+        nonce: Nonce | None = None,
     ) -> ReceiptBreakdown:
         """Contract call to open a short position.
 
@@ -407,6 +414,8 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
             Amount of slippage allowed from the trade.
             If None, then execute the trade regardless of the slippage.
             If not None, then the trade will not execute unless the slippage is below this value.
+        nonce: Nonce | None
+            An optional explicit nonce to set with the transaction
 
         Returns
         -------
@@ -443,7 +452,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
             as_underlying,
         )
         tx_receipt = await async_smart_contract_transact(
-            self.web3, self.hyperdrive_contract, agent, "openShort", *fn_args
+            self.web3, self.hyperdrive_contract, agent, "openShort", *fn_args, nonce=nonce
         )
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "openShort")
         return trade_result
@@ -454,6 +463,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
         trade_amount: FixedPoint,
         maturity_time: int,
         slippage_tolerance: FixedPoint | None = None,
+        nonce: Nonce | None = None,
     ) -> ReceiptBreakdown:
         """Contract call to close a short position.
 
@@ -469,6 +479,8 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
             Amount of slippage allowed from the trade.
             If None, then execute the trade regardless of the slippage.
             If not None, then the trade will not execute unless the slippage is below this value.
+        nonce: Nonce | None
+            An optional explicit nonce to set with the transaction
 
         Returns
         -------
@@ -500,7 +512,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
                 as_underlying,
             )
         tx_receipt = await async_smart_contract_transact(
-            self.web3, self.hyperdrive_contract, agent, "closeShort", *fn_args
+            self.web3, self.hyperdrive_contract, agent, "closeShort", *fn_args, nonce=nonce
         )
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "closeShort")
         return trade_result
@@ -511,6 +523,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
         trade_amount: FixedPoint,
         min_apr: FixedPoint,
         max_apr: FixedPoint,
+        nonce: Nonce | None = None,
     ) -> ReceiptBreakdown:
         """Contract call to add liquidity to the Hyperdrive pool.
 
@@ -524,6 +537,8 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
             The minimum allowable APR after liquidity is added.
         max_apr: FixedPoint
             The maximum allowable APR after liquidity is added.
+        nonce: Nonce | None
+            An optional explicit nonce to set with the transaction
 
         Returns
         -------
@@ -540,7 +555,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
             as_underlying,
         )
         tx_receipt = await async_smart_contract_transact(
-            self.web3, self.hyperdrive_contract, agent, "addLiquidity", *fn_args
+            self.web3, self.hyperdrive_contract, agent, "addLiquidity", *fn_args, nonce=nonce
         )
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "addLiquidity")
         return trade_result
@@ -549,6 +564,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
         self,
         agent: LocalAccount,
         trade_amount: FixedPoint,
+        nonce: Nonce | None = None,
     ) -> ReceiptBreakdown:
         """Contract call to remove liquidity from the Hyperdrive pool.
 
@@ -558,6 +574,8 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
             The account for the agent that is executing and signing the trade transaction.
         trade_amount: FixedPoint
             The size of the position, in base.
+        nonce: Nonce | None
+            An optional explicit nonce to set with the transaction
 
         Returns
         -------
@@ -574,7 +592,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
             as_underlying,
         )
         tx_receipt = await async_smart_contract_transact(
-            self.web3, self.hyperdrive_contract, agent, "removeLiquidity", *fn_args
+            self.web3, self.hyperdrive_contract, agent, "removeLiquidity", *fn_args, nonce=nonce
         )
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "removeLiquidity")
         return trade_result
@@ -583,6 +601,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
         self,
         agent: LocalAccount,
         trade_amount: FixedPoint,
+        nonce: Nonce | None = None,
     ) -> ReceiptBreakdown:
         """Contract call to redeem withdraw shares from Hyperdrive pool.
 
@@ -602,6 +621,8 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
             The size of the position, in base.
         min_output: FixedPoint
             The minimum output amount
+        nonce: Nonce | None
+            An optional explicit nonce to set with the transaction
 
         Returns
         -------
@@ -619,11 +640,7 @@ class HyperdriveInterface(BaseInterface[HyperdriveAddresses]):
             as_underlying,
         )
         tx_receipt = await async_smart_contract_transact(
-            self.web3,
-            self.hyperdrive_contract,
-            agent,
-            "redeemWithdrawalShares",
-            *fn_args,
+            self.web3, self.hyperdrive_contract, agent, "redeemWithdrawalShares", *fn_args, nonce=nonce
         )
         trade_result = parse_logs(tx_receipt, self.hyperdrive_contract, "redeemWithdrawalShares")
         return trade_result

--- a/tests/multi_trade_per_block_test.py
+++ b/tests/multi_trade_per_block_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import pandas as pd
 from agent0 import build_account_key_config_from_agent_config
@@ -16,12 +16,14 @@ from chainsync.exec import acquire_data, data_analysis
 from elfpy.types import MarketType, Trade
 from eth_typing import URI
 from ethpy import EthConfig
-from ethpy.hyperdrive import HyperdriveAddresses, HyperdriveInterface
-from ethpy.test_fixtures.local_chain import DeployedHyperdrivePool
 from fixedpointmath import FixedPoint
 from numpy.random._generator import Generator as NumpyGenerator
 from sqlalchemy.orm import Session
 from web3 import HTTPProvider
+
+if TYPE_CHECKING:
+    from ethpy.hyperdrive import HyperdriveAddresses, HyperdriveInterface
+    from ethpy.test_fixtures.local_chain import DeployedHyperdrivePool
 
 
 class MultiTradePolicy(HyperdrivePolicy):


### PR DESCRIPTION
This PR allows for funding eth, base, and base approvals with bots in async. This allows setup of bots on a chain mined via time quickly, with a large number of bots.

Part of this was a refactor to smart_contract_write calls to allow for a manual nonce parameter. This is needed for funding, as we launch multiple transactions at the same time. The previous method of getting the transaction count from web3 resulted in nonce errors.

The above also fixes an issue when an agent launches multiple trades on the same block.

Also fixes logging to the `.logging` directory