### PR TITLE
use min and max apr in add liquidity call

### DIFF
--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -17,7 +17,6 @@ from agent0.hyperdrive.state import (
 from elfpy import types
 from ethpy.base import retry_call
 from ethpy.hyperdrive import HyperdriveInterface
-from fixedpointmath import FixedPoint
 from web3.types import Nonce
 
 if TYPE_CHECKING:

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -235,9 +235,10 @@ async def async_match_contract_call_to_trade(
             )
 
         case HyperdriveActionType.ADD_LIQUIDITY:
-            # TODO: The following variables are hard coded for now, but should be specified in the trade spec
-            min_apr = FixedPoint(scaled_value=1)  # 1e-18
-            max_apr = FixedPoint(1)  # 1.0
+            min_apr = trade.min_apr
+            assert min_apr, "min_apr is required for ADD_LIQUIDITY"
+            max_apr = trade.max_apr
+            assert max_apr, "max_apr is required for ADD_LIQUIDITY"
             trade_result = await hyperdrive.async_add_liquidity(
                 agent, trade.trade_amount, min_apr, max_apr, nonce=nonce
             )

--- a/lib/agent0/agent0/hyperdrive/state/hyperdrive_actions.py
+++ b/lib/agent0/agent0/hyperdrive/state/hyperdrive_actions.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
+from fixedpointmath import FixedPoint
+
 from agent0.base import freezable
 from elfpy.markets.base import BaseMarketAction
-from fixedpointmath import FixedPoint
 
 from .hyperdrive_wallet import HyperdriveWallet
 
 
 class HyperdriveActionType(Enum):
-    r"""The descriptor of an action in a market"""
+    r"""The descriptor of an action in a market."""
+
     INITIALIZE_MARKET = "initialize_market"
 
     OPEN_LONG = "open_long"
@@ -29,7 +31,8 @@ class HyperdriveActionType(Enum):
 @freezable(frozen=False, no_new_attribs=True)
 @dataclass
 class HyperdriveMarketAction(BaseMarketAction):
-    r"""Market action specification"""
+    r"""Market action specification."""
+
     # these two variables are required to be set by the strategy
     action_type: HyperdriveActionType
     # amount to supply for the action
@@ -40,3 +43,6 @@ class HyperdriveMarketAction(BaseMarketAction):
     slippage_tolerance: FixedPoint | None = None
     # maturity time is set only for trades that act on existing positions (close long or close short)
     maturity_time: int | None = None
+    # min_apr and max_apr used only for add_liquidity trades to control slippage
+    min_apr: FixedPoint = FixedPoint(scaled_value=1)
+    max_apr: FixedPoint = FixedPoint(scaled_value=2**256 - 1)


### PR DESCRIPTION
allows passing in min_apr and max_apr to add liquidity trades, like this:
```py
# Add liquidity
action_list.append(
    Trade(
        market_type=MarketType.HYPERDRIVE,
        market_action=HyperdriveMarketAction(
            action_type=HyperdriveActionType.ADD_LIQUIDITY,
            trade_amount=self.lp_amount,
            wallet=wallet,
            min_apr=fixed_rate - self.policy_config.rate_slippage,
            max_apr=fixed_rate + self.policy_config.rate_slippage,
        ),
    )
)
```