### PR TITLE
No longer setting maturity time when not set

### DIFF
--- a/lib/agent0/agent0/hyperdrive/agents/hyperdrive_account.py
+++ b/lib/agent0/agent0/hyperdrive/agents/hyperdrive_account.py
@@ -158,10 +158,6 @@ class HyperdriveAgent(EthAgent[Policy, HyperdriveInterface, HyperdriveMarketActi
         # edit each action in place
         for action in actions:
             if action.market_type == MarketType.HYPERDRIVE and action.market_action.maturity_time is None:
-                # TODO market latest_checkpoint_time and position_duration should be in ints
-                action.market_action.maturity_time = (
-                    interface.seconds_since_latest_checkpoint + interface.pool_config["positionDuration"]
-                )
                 if action.market_action.trade_amount <= 0:
                     raise ValueError("Trade amount cannot be zero or negative.")
         return actions


### PR DESCRIPTION
The maturity time set in the trade when a maturity time isn't explicitly set is not in the same units of other maturity times. Removing this functionality in favor of having the market action be only the known arguments.