### PR TITLE
Wrapping contract calls in custom exception

### DIFF
--- a/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
+++ b/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
@@ -60,7 +60,7 @@ class ExtendedJSONEncoder(json.JSONEncoder):
             return str(o)
         if isinstance(o, TracebackType):
             return format_tb(o)
-        if isinstance(o, Exception):
+        if isinstance(o, BaseException):
             return repr(o)
 
         try:
@@ -91,7 +91,7 @@ def setup_hyperdrive_crash_report_logging(log_format_string: str | None = None) 
 
 
 def build_crash_trade_result(
-    exception: Exception,
+    exception: BaseException,
     agent: HyperdriveAgent,
     trade_object: types.Trade[HyperdriveMarketAction],
     hyperdrive: HyperdriveInterface,
@@ -114,10 +114,13 @@ def build_crash_trade_result(
     # due to async conditions. If debugging this crash, ensure the agent is running
     # in isolation and doing one trade per call.
 
-    # We get the underlying contract info and convert them to human readable versions
-    # Dispite these being protected variables, we need low level access for crash reporting
-    # TODO we likely should call underlying web3 commands here to prevent race conditions
+    # Instead of using the interface here, we directly call the underlying contract methods
+    # to ensure all data is from the same block.
     trade_result.block_number = hyperdrive.current_block_number
+
+    # We get the underlying contract info and convert them to human readable versions
+    # Despite these being protected variables, we need low level access for crash reporting
+    # TODO we likely should call underlying web3 commands here to prevent race conditions
     trade_result.block_timestamp = hyperdrive.current_block_time
     trade_result.exception = exception
     trade_result.raw_pool_config = hyperdrive._contract_pool_config  # pylint: disable=protected-access

--- a/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
+++ b/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
@@ -41,8 +41,9 @@ if TYPE_CHECKING:
 
 class ExtendedJSONEncoder(json.JSONEncoder):
     r"""Custom encoder for JSON string dumps"""
-    # pylint: disable=too-many-return-statements
 
+    # pylint: disable=too-many-return-statements
+    # pylint: disable=too-many-branches
     def default(self, o):
         r"""Override default behavior"""
         if isinstance(o, set):

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -97,7 +97,7 @@ async def async_execute_single_agent_trade(
         if isinstance(result, HyperdriveWalletDeltas):
             agent.wallet.update(result)
             trade_result = TradeResult(status=TradeStatus.SUCCESS, agent=agent, trade_object=trade_object)
-        elif isinstance(result, Exception):
+        elif isinstance(result, BaseException):
             trade_result = build_crash_trade_result(result, agent, trade_object, hyperdrive)
         else:  # Should never get here
             # TODO: use match statement and assert_never(result)

--- a/lib/agent0/agent0/hyperdrive/exec/trade_loop.py
+++ b/lib/agent0/agent0/hyperdrive/exec/trade_loop.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from agent0.hyperdrive.agents import HyperdriveAgent
 from agent0.hyperdrive.crash_report import get_anvil_state_dump, log_hyperdrive_crash_report
 from agent0.hyperdrive.state import HyperdriveActionType, TradeResult, TradeStatus
+from ethpy.base.errors import ContractCallException
 from ethpy.hyperdrive import HyperdriveInterface
 from web3 import Web3
 from web3.exceptions import ContractCustomError, ContractLogicError
@@ -137,12 +138,14 @@ def check_for_slippage(trade_result) -> tuple[bool, TradeResult]:
         A tuple of a flag for detecting slippage and
         a modified trade_result that has a custom exception argument message prepended
     """
-    # To detect slippage, we look for the `OutputLimit` exception thrown from the smart contract.
+    # To detect slippage, we first look for the wrapper that defines a contract call exception.
+    # We then look for the `OutputLimit` exception thrown as the original exception.
     # Since this exception is used elsewhere (e.g., in redeem withdraw shares), we also explicitly check
     # that the trade here is open/close long/short.
     # TODO this error is not guaranteed to be exclusive for slippage in the future.
     is_slippage = (
-        isinstance(trade_result.exception, ContractCustomError)
+        isinstance(trade_result.exception, ContractCallException)
+        and isinstance(trade_result.exception.orig_exception, ContractCustomError)
         and ("OutputLimit raised" in trade_result.exception.args[1])
         and (
             trade_result.trade_object.market_action.action_type
@@ -220,8 +223,10 @@ def check_for_invalid_balance(trade_result: TradeResult) -> tuple[bool, TradeRes
 
             # We explicitly check for the error here to set flag
             # TODO this catch is not guaranteed to be correct in the future.
-            if isinstance(trade_result.exception, ContractLogicError) and (
-                "ERC20: transfer amount exceeds balance" in trade_result.exception.args[0]
+            if (
+                isinstance(trade_result.exception, ContractCallException)
+                and isinstance(trade_result.exception.orig_exception, ContractLogicError)
+                and ("ERC20: transfer amount exceeds balance" in trade_result.exception.args[0])
             ):
                 invalid_balance = True
 

--- a/lib/agent0/agent0/hyperdrive/exec/trade_loop.py
+++ b/lib/agent0/agent0/hyperdrive/exec/trade_loop.py
@@ -146,7 +146,7 @@ def check_for_slippage(trade_result) -> tuple[bool, TradeResult]:
     is_slippage = (
         isinstance(trade_result.exception, ContractCallException)
         and isinstance(trade_result.exception.orig_exception, ContractCustomError)
-        and ("OutputLimit raised" in trade_result.exception.args[1])
+        and ("OutputLimit raised" in trade_result.exception.orig_exception.args[1])
         and (
             trade_result.trade_object.market_action.action_type
             in (

--- a/lib/agent0/agent0/hyperdrive/state/trade_result.py
+++ b/lib/agent0/agent0/hyperdrive/state/trade_result.py
@@ -32,7 +32,7 @@ class TradeResult:
         The status of the trade
     agent : HyperdriveAgent
         The agent that was executing the trade
-    exception : Exception | None
+    exception : BaseException | None
         The exception that was thrown
     pool_config : dict[str, Any]
         The configuration of the pool
@@ -53,7 +53,7 @@ class TradeResult:
     # These fields are typically set as human readable versions
     block_number: int | None = None
     block_timestamp: int | None = None
-    exception: Exception | None | None = None
+    exception: BaseException | None | None = None
     pool_config: dict[str, Any] | None = None
     pool_info: dict[str, Any] | None = None
     checkpoint_info: dict[str, Any] | None = None

--- a/lib/agent0/agent0/hyperdrive/state/trade_result.py
+++ b/lib/agent0/agent0/hyperdrive/state/trade_result.py
@@ -53,14 +53,15 @@ class TradeResult:
     # These fields are typically set as human readable versions
     block_number: int | None = None
     block_timestamp: int | None = None
-    exception: BaseException | None | None = None
+    exception: BaseException | None = None
+    orig_exception: BaseException | None = None
     pool_config: dict[str, Any] | None = None
     pool_info: dict[str, Any] | None = None
     checkpoint_info: dict[str, Any] | None = None
     contract_addresses: dict[str, Any] | None = None
     additional_info: dict[str, Any] | None = None
     # Machine readable states
-    raw_trade_object: dict[str, Any] | None = None
+    contract_call: dict[str, Any] | None = None
     raw_pool_config: dict[str, Any] | None = None
     raw_pool_info: dict[str, Any] | None = None
     raw_checkpoint: dict[str, Any] | None = None

--- a/lib/ethpy/ethpy/base/errors/__init__.py
+++ b/lib/ethpy/ethpy/base/errors/__init__.py
@@ -1,3 +1,3 @@
 """Custom error reporting and contract error parsing."""
-from .errors import decode_error_selector_for_contract
+from .errors import ContractCallException, ContractCallType, decode_error_selector_for_contract
 from .types import ABIError, UnknownBlockError

--- a/lib/ethpy/ethpy/base/errors/errors.py
+++ b/lib/ethpy/ethpy/base/errors/errors.py
@@ -1,10 +1,44 @@
 """Error handling for the hyperdrive ecosystem"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
 
 from eth_utils.conversions import to_hex
 from eth_utils.crypto import keccak
 from web3.contract.contract import Contract
 
 from .types import ABIError
+
+
+class ContractCallType(Enum):
+    r"""A type of token"""
+
+    PREVIEW = "preview"
+    TRANSACTION = "transaction"
+    READ = "read"
+
+
+class ContractCallException(BaseException):
+    """Custom contract call exception wrapper that contains additional information on the function call"""
+
+    def __init__(
+        self,
+        *args,
+        orig_exception: BaseException | None = None,
+        contract_call_type: ContractCallType | None = None,
+        function_name_or_signature: str | None = None,
+        fn_args: tuple | None = None,
+        fn_kwargs: dict[str, Any] | None = None,
+        block_number: int | None = None,
+    ):
+        super().__init__(*args)
+        self.orig_exception = orig_exception
+        self.contract_call_type = contract_call_type
+        self.function_name_or_signature = function_name_or_signature
+        self.fn_args = fn_args
+        self.fn_kwargs = fn_kwargs
+        self.block_number = block_number
 
 
 def decode_error_selector_for_contract(error_selector: str, contract: Contract) -> str:

--- a/lib/ethpy/ethpy/base/errors/errors.py
+++ b/lib/ethpy/ethpy/base/errors/errors.py
@@ -22,9 +22,13 @@ class ContractCallType(Enum):
 class ContractCallException(BaseException):
     """Custom contract call exception wrapper that contains additional information on the function call"""
 
+    # We'd like to pass in these optional kwargs to this exception
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         *args,
+        # Explicitly passing these arguments as kwargs to allow for multiple `args` to be passed in
+        # similar for other types of exceptions
         orig_exception: BaseException | None = None,
         contract_call_type: ContractCallType | None = None,
         function_name_or_signature: str | None = None,

--- a/lib/ethpy/ethpy/base/transactions.py
+++ b/lib/ethpy/ethpy/base/transactions.py
@@ -26,11 +26,6 @@ from .retry_utils import retry_call
 
 # TODO these should be parameterized so the caller controls how many times to retry
 READ_RETRY_COUNT = 5
-# Not retrying on write counts
-# TODO need to figure out exactly which error is due to an anvil error
-# Currently catching write when status=0, but ideally this would be a specific
-# "anvil is breaking" error. We're currently disabling by setting WRITE_RETRY_COUNT to 1.
-WRITE_RETRY_COUNT = 1
 
 
 def smart_contract_read(contract: Contract, function_name_or_signature: str, *fn_args, **fn_kwargs) -> dict[str, Any]:
@@ -69,7 +64,8 @@ def smart_contract_read(contract: Contract, function_name_or_signature: str, *fn
     except Exception as err:
         # Add additional information to the exception
         # This field is passed in if smart_contract_read is called with an explicit block
-        # TODO get current block number if this field wasn't passed into this call
+        # Will default to None, in which case crash reporting will do best attempt at getting
+        # the block number
         block_number = fn_kwargs.get("block_identifier", None)
         raise ContractCallException(
             "Error in smart contract read",
@@ -163,7 +159,8 @@ def smart_contract_preview_transaction(
     except Exception as err:
         # Add additional information to the exception
         # This field is passed in if smart_contract_read is called with an explicit block
-        # TODO get current block number if this field wasn't passed into this call
+        # Will default to None, in which case crash reporting will do best attempt at getting
+        # the block number
         block_number = fn_kwargs.get("block_identifier", None)
         raise ContractCallException(
             "Error in preview transaction",
@@ -284,7 +281,6 @@ async def _async_send_transaction_and_wait_for_receipt(
     )
     signed_txn = signer.sign_transaction(unsent_txn)
     tx_hash = web3.eth.send_raw_transaction(signed_txn.rawTransaction)
-    # TODO set poll time as a parameter
     tx_receipt = await async_wait_for_transaction_receipt(web3, tx_hash)
 
     # Error checking when transaction doesn't throw an error, but instead
@@ -350,10 +346,12 @@ async def async_smart_contract_transact(
             nonce=nonce,
         )
 
+    # Wraps the exception with a contract call exception, adding additional information
+    # Other than UnknownBlockError, which gets the block number from the transaction receipt,
+    # the rest will default to setting the block number to None, which then crash reporting
+    # will attempt a best effort guess as to the block the chain was on before it crashed.
     except ContractCustomError as err:
         err.args += (f"ContractCustomError {decode_error_selector_for_contract(err.args[0], contract)} raised.",)
-        # Add additional information to the exception
-        # TODO get block number of the call here
         raise ContractCallException(
             "Error in smart_contract_transact",
             orig_exception=err,
@@ -363,8 +361,6 @@ async def async_smart_contract_transact(
             fn_kwargs={},
         ) from err
     except ContractLogicError as err:
-        # Add additional information to the exception
-        # TODO get block number of the call here
         raise ContractCallException(
             "Error in smart_contract_transact",
             orig_exception=err,
@@ -387,8 +383,6 @@ async def async_smart_contract_transact(
             block_number=block_number,
         ) from err
     except Exception as err:
-        # Add additional information to the exception
-        # TODO get block number of the call here
         raise ContractCallException(
             "Error in smart_contract_transact",
             orig_exception=err,
@@ -442,7 +436,6 @@ def _send_transaction_and_wait_for_receipt(
     )
     signed_txn = signer.sign_transaction(unsent_txn)
     tx_hash = web3.eth.send_raw_transaction(signed_txn.rawTransaction)
-    # TODO set poll time as a parameter
     tx_receipt = web3.eth.wait_for_transaction_receipt(tx_hash)
 
     # Error checking when transaction doesn't throw an error, but instead
@@ -501,14 +494,17 @@ def smart_contract_transact(
         else:
             func_handle = contract.get_function_by_name(function_name_or_signature)(*fn_args)
         return _send_transaction_and_wait_for_receipt(func_handle, signer, web3, nonce)
+
+    # Wraps the exception with a contract call exception, adding additional information
+    # Other than UnknownBlockError, which gets the block number from the transaction receipt,
+    # the rest will default to setting the block number to None, which then crash reporting
+    # will attempt a best effort guess as to the block the chain was on before it crashed.
     except ContractCustomError as err:
         err.args += (
             f"ContractCustomError {decode_error_selector_for_contract(err.args[0], contract)} raised.\n"
             + f"function name: {function_name_or_signature}"
             + f"\nfunction args: {fn_args}",
         )
-        # Add additional information to the exception
-        # TODO get block number of the call here
         raise ContractCallException(
             "Error in smart_contract_transact",
             orig_exception=err,
@@ -518,8 +514,6 @@ def smart_contract_transact(
             fn_kwargs={},
         ) from err
     except ContractLogicError as err:
-        # Add additional information to the exception
-        # TODO get block number of the call here
         raise ContractCallException(
             "Error in smart_contract_transact",
             orig_exception=err,
@@ -542,8 +536,6 @@ def smart_contract_transact(
             block_number=block_number,
         ) from err
     except Exception as err:
-        # Add additional information to the exception
-        # TODO get block number of the call here
         raise ContractCallException(
             "Error in smart_contract_transact",
             orig_exception=err,
@@ -657,7 +649,6 @@ def eth_transfer(
         "from": signer_checksum_address,
         "to": to_address,
         "value": Wei(amount_wei),
-        # TODO figure out which exception here to retry on
         "nonce": nonce,
         "chainId": web3.eth.chain_id,
     }
@@ -673,9 +664,6 @@ def eth_transfer(
     unsent_txn["maxPriorityFeePerGas"] = Wei(max_priority_fee)
     signed_txn = signer.sign_transaction(unsent_txn)
 
-    # TODO how do we want to handle retries here?
-    # While this is fine for exceptions thrown, we may need to handle the case where the log status
-    # return fail
     tx_hash = web3.eth.send_raw_transaction(signed_txn.rawTransaction)
     return web3.eth.wait_for_transaction_receipt(tx_hash)
 

--- a/tests/multi_trade_per_block_test.py
+++ b/tests/multi_trade_per_block_test.py
@@ -16,6 +16,7 @@ from chainsync.exec import acquire_data, data_analysis
 from elfpy.types import MarketType, Trade
 from eth_typing import URI
 from ethpy import EthConfig
+from ethpy.base.errors import ContractCallException
 from fixedpointmath import FixedPoint
 from numpy.random._generator import Generator as NumpyGenerator
 from sqlalchemy.orm import Session
@@ -187,10 +188,8 @@ class TestMultiTradePerBlock:
             )
             # If this reaches this point, the agent was successful, which means this test should fail
             assert False, "Agent was successful with known invalid trade"
-        except AssertionError as exc:
+        except ContractCallException as exc:
             # Expected error due to illegal trade
-            # TODO currently, the illegal trade is throwing an assertion error
-            # due to a lack of a trx receipt. Ideally, this error should be more informative
             # We do add an argument for invalid balance to the args, so check for that here
             assert "Invalid balance:" in exc.args[0]
 

--- a/tests/slippage_warning_test.py
+++ b/tests/slippage_warning_test.py
@@ -11,6 +11,7 @@ from agent0.hyperdrive.exec import run_agents
 from agent0.test_fixtures import CycleTradesPolicy
 from eth_typing import URI
 from ethpy import EthConfig
+from ethpy.base.errors import ContractCallException
 from fixedpointmath import FixedPoint
 from web3 import HTTPProvider
 from web3.exceptions import ContractCustomError
@@ -115,5 +116,5 @@ class TestSlippageWarning:
                 contract_addresses=hyperdrive_contract_addresses,
                 load_wallet_state=False,
             )
-        except ContractCustomError as exc:
+        except ContractCallException as exc:
             assert "Slippage detected" in exc.args[0]

--- a/tests/slippage_warning_test.py
+++ b/tests/slippage_warning_test.py
@@ -14,7 +14,6 @@ from ethpy import EthConfig
 from ethpy.base.errors import ContractCallException
 from fixedpointmath import FixedPoint
 from web3 import HTTPProvider
-from web3.exceptions import ContractCustomError
 
 if TYPE_CHECKING:
     from ethpy.hyperdrive import HyperdriveAddresses


### PR DESCRIPTION
The custom exception stores data including the exact contract call and the block number that the call was attempted on. Additionally, all hyperdrive state info grabs data from the block that the crash failed on.

Examples

Human readable
```
23-10-24 14:05:25: CRITICAL: crash_report.log_hyperdrive_crash_report:
{
  "log_time": "2023-10-24T21:05:25.486811+00:00",
  "block_number": 15,
  "block_timestamp": 1698181537,
  "exception": "ContractCallException('Invalid balance: REDEEM_WITHDRAW_SHARE for 99999999999.0 withdraw shares, balance of 0.0 withdraw shares.', 'Error in smart_contract_transact')",
  "orig_exception": "UnknownBlockError('Logs have a length of 0', 'block_number=15', \"tx_receipt=AttributeDict({'transactionHash': HexBytes('0x2fc23b24a6e8344cca2527d0a38c571f92f8b778b99c0aa6afa752706a5b7404'), 'transactionIndex': 0, 'blockHash': HexBytes('0xbb428cbd8775b0c00a432b87e307cb66c5cd7f66c315e96ac227005d135d833d'), 'blockNumber': 16, 'from': '0xb28F7AA69c4451b2b942b50a017CA21a63DB3c3f', 'to': '0xd8058efe0198ae9dD7D563e1b4938Dcbc86A1F81', 'cumulativeGasUsed': 77042, 'gasUsed': 77042, 'contractAddress': None, 'logs': [], 'status': 1, 'logsBloom': HexBytes('0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'), 'type': 2, 'effectiveGasPrice': 1501690774})\")",
  "trade": {
    "market_type": "HYPERDRIVE",
    "action_type": "REDEEM_WITHDRAW_SHARE",
    "trade_amount": "99999999999.0",
    "slippage_tolerance": null,
    "maturity_time": null
  },
  "wallet": {
    "base": "966615.435727223931266024",
    "longs": [
      {
        "maturity_time": 1698786000,
        "balance": "22240.960380161547270613"
      }
    ],
    "shorts": [
      {
        "maturity_time": 1698786000,
        "balance": "33333.0"
      }
    ],
    "lp_tokens": "11110.999911918126025819",
    "withdraw_shares": "0.0"
  },
  "agent_info": {
    "address": "0xb28F7AA69c4451b2b942b50a017CA21a63DB3c3f",
    "policy": "MultiTradePolicy"
  },
  "pool_config": {
    "baseToken": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
    "initialSharePrice": "1.0",
    "minimumShareReserves": "10.0",
    "minimumTransactionAmount": "0.001",
    "positionDuration": 604800,
    "checkpointDuration": 3600,
    "timeStretch": "0.044463125629060298",
    "governance": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
    "feeCollector": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
    "fees": [
      "0.1",
      "0.0005",
      "0.15"
    ],
    "oracleSize": 10,
    "updateGap": 3600,
    "contractAddress": "0xd8058efe0198ae9dD7D563e1b4938Dcbc86A1F81",
    "curveFee": "0.1",
    "flatFee": "0.0005",
    "governanceFee": "0.15",
    "invTimeStretch": "22.490546623794212364"
  },
  "pool_info": {
    "shareReserves": "100000034.108928545614273651",
    "shareAdjustment": "0.0",
    "bondReserves": "102201440.023392445630509228",
    "lpTotalSupply": "100011100.999911918126025819",
    "sharePrice": "1.00000001109842722",
    "longsOutstanding": "22240.960380161547270613",
    "longAverageMaturityTime": "1698786000.0",
    "shortsOutstanding": "33333.0",
    "shortAverageMaturityTime": "1698786000.0",
    "withdrawalSharesReadyToWithdraw": "0.0",
    "withdrawalSharesProceeds": "0.0",
    "lpSharePrice": "1.00000005577833847",
    "longExposure": "0.0",
    "timestamp": "2023-10-24 21:05:37",
    "blockNumber": 15,
    "totalSupplyWithdrawalShares": 0
  },
  "checkpoint_info": {
    "sharePrice": "1.0",
    "longExposure": "-11072.759914372402916331",
    "blockNumber": 15,
    "timestamp": "2023-10-24 14:05:37"
  },
  "contract_addresses": {
    "hyperdrive_address": "0xd8058efe0198ae9dD7D563e1b4938Dcbc86A1F81",
    "base_token_address": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
  },
  "additional_info": {
    "spot_price": "0.999032273280673843",
    "fixed_rate": "0.050508914905668004",
    "variable_rate": "0.05",
    "vault_shares": "100033384.563972725414955382"
  },
  "traceback": [
    "  File \"/Users/slundquist/workspace/elf-simulations/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py\", line 250, in async_match_contract_call_to_trade\n    trade_result = await hyperdrive.async_redeem_withdraw_shares(agent, trade.trade_amount, nonce=nonce)\n",
    "  File \"/Users/slundquist/workspace/elf-simulations/lib/ethpy/ethpy/hyperdrive/api.py\", line 921, in async_redeem_withdraw_shares\n    tx_receipt = await async_smart_contract_transact(\n",
    "  File \"/Users/slundquist/workspace/elf-simulations/lib/ethpy/ethpy/base/transactions.py\", line 380, in async_smart_contract_transact\n    raise ContractCallException(\n"
  ],
  "orig_traceback": [
    "  File \"/Users/slundquist/workspace/elf-simulations/lib/ethpy/ethpy/base/transactions.py\", line 346, in async_smart_contract_transact\n    return await _async_send_transaction_and_wait_for_receipt(\n",
    "  File \"/Users/slundquist/workspace/elf-simulations/lib/ethpy/ethpy/base/transactions.py\", line 305, in _async_send_transaction_and_wait_for_receipt\n    raise UnknownBlockError(\"Logs have a length of 0\", f\"{block_number=}\", f\"{tx_receipt=}\")\n"
  ],
  "commit_hash": "a4cbf03b875f76033958f1ebc7c28d325085ec18"
}
```

Example corresponding machine readable crash report attached.

[2023_10_24_21_05_25_Z.json](https://github.com/delvtech/elf-simulations/files/13127459/2023_10_24_21_05_25_Z.json)
