### PR TITLE
Raw transaction in crash report

### DIFF
--- a/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
+++ b/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
@@ -134,6 +134,7 @@ def build_crash_trade_result(
             "fn_args": exception.fn_args,
             "fn_kwargs": exception.fn_kwargs,
         }
+        trade_result.raw_transaction = exception.raw_txn
 
     else:
         # Best effort to get the block it crashed on
@@ -259,6 +260,7 @@ def log_hyperdrive_crash_report(
             ("exception", trade_result.exception),
             ("orig_exception", trade_result.orig_exception),
             ("trade", _hyperdrive_trade_obj_to_dict(trade_result.trade_object)),
+            ("contract_call", trade_result.contract_call),
             ("wallet", _hyperdrive_wallet_to_dict(trade_result.agent.wallet)),
             ("agent_info", _hyperdrive_agent_to_dict(trade_result.agent)),
             # TODO Once pool_info and pool_config are objects,
@@ -285,7 +287,7 @@ def log_hyperdrive_crash_report(
     if crash_report_to_file:
         # We add the machine readable version of the crash to the file
         # OrderedDict doesn't play nice with types
-        dump_obj["contract_call"] = trade_result.contract_call  # type: ignore
+        dump_obj["raw_transaction"] = trade_result.raw_transaction  # type: ignore
         dump_obj["raw_pool_config"] = trade_result.raw_pool_config  # type: ignore
         dump_obj["raw_pool_info"] = trade_result.raw_pool_info  # type: ignore
         dump_obj["raw_checkpoint"] = trade_result.raw_checkpoint  # type: ignore

--- a/lib/agent0/agent0/hyperdrive/state/trade_result.py
+++ b/lib/agent0/agent0/hyperdrive/state/trade_result.py
@@ -49,6 +49,7 @@ class TradeResult:
     status: TradeStatus
     agent: HyperdriveAgent
     trade_object: types.Trade[HyperdriveMarketAction]
+    contract_call: dict[str, Any] | None = None
     # Optional fields for crash reporting
     # These fields are typically set as human readable versions
     block_number: int | None = None
@@ -61,7 +62,7 @@ class TradeResult:
     contract_addresses: dict[str, Any] | None = None
     additional_info: dict[str, Any] | None = None
     # Machine readable states
-    contract_call: dict[str, Any] | None = None
+    raw_transaction: dict[str, Any] | None = None
     raw_pool_config: dict[str, Any] | None = None
     raw_pool_info: dict[str, Any] | None = None
     raw_checkpoint: dict[str, Any] | None = None

--- a/lib/ethpy/ethpy/base/errors/errors.py
+++ b/lib/ethpy/ethpy/base/errors/errors.py
@@ -34,6 +34,7 @@ class ContractCallException(BaseException):
         function_name_or_signature: str | None = None,
         fn_args: tuple | None = None,
         fn_kwargs: dict[str, Any] | None = None,
+        raw_txn: dict[str, Any] | None = None,
         block_number: int | None = None,
     ):
         super().__init__(*args)
@@ -43,6 +44,7 @@ class ContractCallException(BaseException):
         self.fn_args = fn_args
         self.fn_kwargs = fn_kwargs
         self.block_number = block_number
+        self.raw_txn = raw_txn
 
 
 def decode_error_selector_for_contract(error_selector: str, contract: Contract) -> str:

--- a/lib/ethpy/ethpy/base/transactions.py
+++ b/lib/ethpy/ethpy/base/transactions.py
@@ -66,6 +66,7 @@ def smart_contract_read(contract: Contract, function_name_or_signature: str, *fn
         # This field is passed in if smart_contract_read is called with an explicit block
         # Will default to None, in which case crash reporting will do best attempt at getting
         # the block number
+        # TODO add in raw_txn to smart contract read functions
         block_number = fn_kwargs.get("block_identifier", None)
         raise ContractCallException(
             "Error in smart contract read",

--- a/lib/ethpy/ethpy/base/transactions.py
+++ b/lib/ethpy/ethpy/base/transactions.py
@@ -361,10 +361,11 @@ async def async_smart_contract_transact(
     else:
         func_handle = contract.get_function_by_name(function_name_or_signature)(*fn_args)
 
-    # Build transaction
-    unsent_txn = build_transaction(func_handle, signer, web3, nonce=nonce)
-
+    unsent_txn = {}
     try:
+        # Build transaction
+        # Building transaction can fail when transaction itself isn't correct
+        unsent_txn = build_transaction(func_handle, signer, web3, nonce=nonce)
         return await _async_send_transaction_and_wait_for_receipt(unsent_txn, signer, web3)
 
     # Wraps the exception with a contract call exception, adding additional information
@@ -495,10 +496,12 @@ def smart_contract_transact(
         func_handle = contract.get_function_by_signature(function_name_or_signature)(*fn_args)
     else:
         func_handle = contract.get_function_by_name(function_name_or_signature)(*fn_args)
-    # Build transaction
-    unsent_txn = build_transaction(func_handle, signer, web3, nonce=nonce)
 
+    unsent_txn = {}
     try:
+        # Build transaction
+        # Building transaction can fail when transaction itself isn't correct
+        unsent_txn = build_transaction(func_handle, signer, web3, nonce=nonce)
         return _send_transaction_and_wait_for_receipt(unsent_txn, signer, web3)
 
     # Wraps the exception with a contract call exception, adding additional information

--- a/lib/ethpy/ethpy/base/transactions.py
+++ b/lib/ethpy/ethpy/base/transactions.py
@@ -140,6 +140,10 @@ def smart_contract_preview_transaction(
     else:
         function = contract.get_function_by_name(function_name_or_signature)(*fn_args)
 
+    # We build the raw transaction here in case of error. Note that we don't call `build_transaction`
+    # since it adds the nonce to the transaction, and we ignore nonce in preview
+    raw_txn = function.build_transaction({"from": signer_address})
+
     # We define the function to check the exception to retry on
     # This is the error we get when preview fails due to anvil
     def retry_preview_check(exc: Exception) -> bool:
@@ -169,6 +173,7 @@ def smart_contract_preview_transaction(
             function_name_or_signature=function_name_or_signature,
             fn_args=fn_args,
             fn_kwargs=fn_kwargs,
+            raw_txn=raw_txn,
             block_number=block_number,
         ) from err
 

--- a/lib/ethpy/ethpy/base/transactions.py
+++ b/lib/ethpy/ethpy/base/transactions.py
@@ -102,6 +102,8 @@ def smart_contract_read(contract: Contract, function_name_or_signature: str, *fn
     return {f"value{idx}": value for idx, value in enumerate(return_values)}
 
 
+# TODO cleanup
+# pylint: disable=too-many-locals
 def smart_contract_preview_transaction(
     contract: Contract,
     signer_address: ChecksumAddress,

--- a/lib/ethpy/ethpy/base/transactions.py
+++ b/lib/ethpy/ethpy/base/transactions.py
@@ -290,14 +290,12 @@ async def _async_send_transaction_and_wait_for_receipt(
 
     Arguments
     ---------
-    func_handle: ContractFunction
-        The function to call
+    unsent_txn: TxParams
+        The built transaction ready to be sent
     signer: LocalAccount
         The LocalAccount that will be used to pay for the gas & sign the transaction
     web3 : Web3
         web3 provider object
-    nonce: Nonce | None
-        If set, will explicitly set the nonce to this value, otherwise will use web3 to get transaction count
 
     Returns
     -------
@@ -427,14 +425,14 @@ def _send_transaction_and_wait_for_receipt(unsent_txn: TxParams, signer: LocalAc
 
     Arguments
     ---------
-    func_handle: ContractFunction
-        The function to call
+    Arguments
+    ---------
+    unsent_txn: TxParams
+        The built transaction ready to be sent
     signer: LocalAccount
         The LocalAccount that will be used to pay for the gas & sign the transaction
     web3 : Web3
         web3 provider object
-    nonce: Nonce | None
-        If set, will explicitly set the nonce to this value, otherwise will use web3 to get transaction count
 
     Returns
     -------


### PR DESCRIPTION
Note: nonce in raw transactions only exist when the crash is a transaction, not in previews.

Example human report:
```
23-10-25 12:09:17: CRITICAL: crash_report.log_hyperdrive_crash_report:
{
  "log_time": "2023-10-25T19:09:17.918504+00:00",
  "block_number": 15,
  "block_timestamp": 1698260959,
  "exception": "ContractCallException('Invalid balance: REDEEM_WITHDRAW_SHARE for 99999999999.0 withdraw shares, balance of 0.0 withdraw shares.', 'Error in smart_contract_transact')",
  "orig_exception": "UnknownBlockError('Logs have a length of 0', 'block_number=15', \"tx_receipt=AttributeDict({'transactionHash': HexBytes('0x1183ef74855b7e536aeb5c99db72898c5c206fd43171b22f9174a272781588ab'), 'transactionIndex': 0, 'blockHash': HexBytes('0x91aaebbc16a691da2d687ab08179563063b8f8419d9a66864e5f6b0a3e8dc42a'), 'blockNumber': 16, 'from': '0x8d915CBD99825A53C7801D916450aa95aE46D843', 'to': '0xd8058efe0198ae9dD7D563e1b4938Dcbc86A1F81', 'cumulativeGasUsed': 77042, 'gasUsed': 77042, 'contractAddress': None, 'logs': [], 'status': 1, 'logsBloom': HexBytes('0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'), 'type': 2, 'effectiveGasPrice': 1501690774})\")",
  "trade": {
    "market_type": "HYPERDRIVE",
    "action_type": "REDEEM_WITHDRAW_SHARE",
    "trade_amount": "99999999999.0",
    "slippage_tolerance": null,
    "maturity_time": null
  },
  "contract_call": {
    "contract_call_type": "TRANSACTION",
    "function_name_or_signature": "redeemWithdrawalShares",
    "fn_args": [
      99999999999000000000000000000,
      1,
      "0x8d915CBD99825A53C7801D916450aa95aE46D843",
      true
    ],
    "fn_kwargs": {}
  },
  "wallet": {
    "base": "966615.435727223931266024",
    "longs": [
      {
        "maturity_time": 1698865200,
        "balance": "22240.960380161547270613"
      }
    ],
    "shorts": [
      {
        "maturity_time": 1698865200,
        "balance": "33333.0"
      }
    ],
    "lp_tokens": "11110.999911918126025819",
    "withdraw_shares": "0.0"
  },
  "agent_info": {
    "address": "0x8d915CBD99825A53C7801D916450aa95aE46D843",
    "policy": "MultiTradePolicy"
  },
  "pool_config": {
    "baseToken": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
    "initialSharePrice": "1.0",
    "minimumShareReserves": "10.0",
    "minimumTransactionAmount": "0.001",
    "positionDuration": 604800,
    "checkpointDuration": 3600,
    "timeStretch": "0.044463125629060298",
    "governance": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
    "feeCollector": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
    "fees": [
      "0.1",
      "0.0005",
      "0.15"
    ],
    "oracleSize": 10,
    "updateGap": 3600,
    "contractAddress": "0xd8058efe0198ae9dD7D563e1b4938Dcbc86A1F81",
    "curveFee": "0.1",
    "flatFee": "0.0005",
    "governanceFee": "0.15",
    "invTimeStretch": "22.490546623794212364"
  },
  "pool_info": {
    "shareReserves": "100000034.108928545614273651",
    "shareAdjustment": "0.0",
    "bondReserves": "102201440.023392445630509228",
    "lpTotalSupply": "100011100.999911918126025819",
    "sharePrice": "1.00000001109842722",
    "longsOutstanding": "22240.960380161547270613",
    "longAverageMaturityTime": "1698865200.0",
    "shortsOutstanding": "33333.0",
    "shortAverageMaturityTime": "1698865200.0",
    "withdrawalSharesReadyToWithdraw": "0.0",
    "withdrawalSharesProceeds": "0.0",
    "lpSharePrice": "1.00000005577833847",
    "longExposure": "0.0",
    "timestamp": "2023-10-25 19:09:19",
    "blockNumber": 15,
    "totalSupplyWithdrawalShares": 0
  },
  "checkpoint_info": {
    "sharePrice": "1.0",
    "longExposure": "-11072.759914372402916331",
    "blockNumber": 15,
    "timestamp": "2023-10-25 12:09:19"
  },
  "contract_addresses": {
    "hyperdrive_address": "0xd8058efe0198ae9dD7D563e1b4938Dcbc86A1F81",
    "base_token_address": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
  },
  "additional_info": {
    "spot_price": "0.999032273280673843",
    "fixed_rate": "0.050508914905668004",
    "variable_rate": "0.05",
    "vault_shares": "100033384.563972725414955382"
  },
  "traceback": [
    "  File \"/Users/slundquist/workspace/elf-simulations/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py\", line 250, in async_match_contract_call_to_trade\n    trade_result = await hyperdrive.async_redeem_withdraw_shares(agent, trade.trade_amount, nonce=nonce)\n",
    "  File \"/Users/slundquist/workspace/elf-simulations/lib/ethpy/ethpy/hyperdrive/api.py\", line 942, in async_redeem_withdraw_shares\n    tx_receipt = await async_smart_contract_transact(\n",
    "  File \"/Users/slundquist/workspace/elf-simulations/lib/ethpy/ethpy/base/transactions.py\", line 399, in async_smart_contract_transact\n    raise ContractCallException(\n"
  ],
  "orig_traceback": [
    "  File \"/Users/slundquist/workspace/elf-simulations/lib/ethpy/ethpy/base/transactions.py\", line 368, in async_smart_contract_transact\n    return await _async_send_transaction_and_wait_for_receipt(unsent_txn, signer, web3)\n",
    "  File \"/Users/slundquist/workspace/elf-simulations/lib/ethpy/ethpy/base/transactions.py\", line 324, in _async_send_transaction_and_wait_for_receipt\n    raise UnknownBlockError(\"Logs have a length of 0\", f\"{block_number=}\", f\"{tx_receipt=}\")\n"
  ],
  "commit_hash": "f8581aec8aac272b563745185418ff62ece25175"
}
```

Machine crash report:

[2023_10_25_19_09_17_Z.json](https://github.com/delvtech/elf-simulations/files/13169718/2023_10_25_19_09_17_Z.json)
