### PR TITLE
easier to adjust api pool state

### DIFF
--- a/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
+++ b/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
@@ -152,7 +152,7 @@ def build_crash_trade_result(
         }
 
     ## Get the pool state at the desired block number
-    pool_state = hyperdrive.get_hyperdrive_state(hyperdrive.block(trade_result.block_number))
+    pool_state = hyperdrive.get_hyperdrive_state(hyperdrive.get_block(trade_result.block_number))
 
     ## Get pool config
     # Pool config is static, so we can get it from the interface here

--- a/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
+++ b/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
@@ -118,7 +118,7 @@ def build_crash_trade_result(
         agent=agent,
         trade_object=trade_object,
     )
-    current_block_number = hyperdrive.block_number(hyperdrive.current_block)
+    current_block_number = hyperdrive.block_number(hyperdrive.get_current_block())
 
     ## Check if the exception came from a contract call & determine block number
     # If it did, we fill various trade result data with custom data from

--- a/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
+++ b/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
@@ -118,7 +118,7 @@ def build_crash_trade_result(
         agent=agent,
         trade_object=trade_object,
     )
-    current_block_number = hyperdrive.block_number(hyperdrive.get_current_block())
+    current_block_number = hyperdrive.get_block_number(hyperdrive.get_current_block())
 
     ## Check if the exception came from a contract call & determine block number
     # If it did, we fill various trade result data with custom data from

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -7,8 +7,10 @@ import warnings
 
 from chainsync.db.base import initialize_session
 from chainsync.db.hyperdrive import (
-    data_chain_to_db, get_latest_block_number_from_pool_info_table,
-    init_data_chain_to_db)
+    data_chain_to_db,
+    get_latest_block_number_from_pool_info_table,
+    init_data_chain_to_db,
+)
 from eth_typing import BlockNumber
 from ethpy import EthConfig
 from ethpy.hyperdrive import HyperdriveAddresses
@@ -63,7 +65,7 @@ def acquire_data(
     block_number: BlockNumber = BlockNumber(max(start_block, data_latest_block_number))
     # Make sure to not grab current block, as the current block is subject to change
     # Current block is still being built
-    latest_mined_block = hyperdrive.block_number(hyperdrive.get_current_block())
+    latest_mined_block = hyperdrive.get_block_number(hyperdrive.get_current_block())
     lookback_block_limit = BlockNumber(lookback_block_limit)
     if (latest_mined_block - block_number) > lookback_block_limit:
         block_number = BlockNumber(latest_mined_block - lookback_block_limit)

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -7,8 +7,10 @@ import warnings
 
 from chainsync.db.base import initialize_session
 from chainsync.db.hyperdrive import (
-    data_chain_to_db, get_latest_block_number_from_pool_info_table,
-    init_data_chain_to_db)
+    data_chain_to_db,
+    get_latest_block_number_from_pool_info_table,
+    init_data_chain_to_db,
+)
 from eth_typing import BlockNumber
 from ethpy import EthConfig
 from ethpy.hyperdrive import HyperdriveAddresses

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -7,10 +7,8 @@ import warnings
 
 from chainsync.db.base import initialize_session
 from chainsync.db.hyperdrive import (
-    data_chain_to_db,
-    get_latest_block_number_from_pool_info_table,
-    init_data_chain_to_db,
-)
+    data_chain_to_db, get_latest_block_number_from_pool_info_table,
+    init_data_chain_to_db)
 from eth_typing import BlockNumber
 from ethpy import EthConfig
 from ethpy.hyperdrive import HyperdriveAddresses
@@ -65,7 +63,7 @@ def acquire_data(
     block_number: BlockNumber = BlockNumber(max(start_block, data_latest_block_number))
     # Make sure to not grab current block, as the current block is subject to change
     # Current block is still being built
-    latest_mined_block = hyperdrive.block_number(hyperdrive.current_block)
+    latest_mined_block = hyperdrive.block_number(hyperdrive.get_current_block())
     lookback_block_limit = BlockNumber(lookback_block_limit)
     if (latest_mined_block - block_number) > lookback_block_limit:
         block_number = BlockNumber(latest_mined_block - lookback_block_limit)

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -7,10 +7,8 @@ import warnings
 
 from chainsync.db.base import initialize_session
 from chainsync.db.hyperdrive import (
-    data_chain_to_db,
-    get_latest_block_number_from_pool_info_table,
-    init_data_chain_to_db,
-)
+    data_chain_to_db, get_latest_block_number_from_pool_info_table,
+    init_data_chain_to_db)
 from eth_typing import BlockNumber
 from ethpy import EthConfig
 from ethpy.hyperdrive import HyperdriveAddresses
@@ -79,7 +77,7 @@ def acquire_data(
     # This if statement executes only on initial run (based on data_latest_block_number check),
     # and if the chain has executed until start_block (based on latest_mined_block check)
     if data_latest_block_number < block_number < latest_mined_block:
-        data_chain_to_db(hyperdrive, hyperdrive.block(block_number), db_session)
+        data_chain_to_db(hyperdrive, hyperdrive.get_block(block_number), db_session)
 
     # Main data loop
     # monitor for new blocks & add pool info per block
@@ -111,5 +109,5 @@ def acquire_data(
                     latest_mined_block,
                 )
                 continue
-            data_chain_to_db(hyperdrive, hyperdrive.block(block_number), db_session)
+            data_chain_to_db(hyperdrive, hyperdrive.get_block(block_number), db_session)
         time.sleep(_SLEEP_AMOUNT)

--- a/lib/ethpy/ethpy/hyperdrive/api/_contract_calls.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/_contract_calls.py
@@ -35,7 +35,7 @@ def _get_total_supply_withdrawal_shares(
         "balanceOf",
         asset_id,
         hyperdrive_contract.address,
-        block_number,
+        block_number=block_number,
     )["value"]
     return FixedPoint(scaled_value=int(total_supply_withdrawal_shares))
 

--- a/lib/ethpy/ethpy/hyperdrive/api/_contract_calls.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/_contract_calls.py
@@ -10,6 +10,7 @@ from ethpy.base import (
     smart_contract_preview_transaction,
     smart_contract_read,
 )
+from ethpy.hyperdrive import AssetIdPrefix, encode_asset_id
 from ethpy.hyperdrive.transactions import parse_logs
 from fixedpointmath import FixedPoint
 from web3 import Web3
@@ -22,6 +23,21 @@ if TYPE_CHECKING:
     from web3.types import Nonce
 
     from .api import HyperdriveInterface
+
+
+def _get_total_supply_withdrawal_shares(
+    hyperdrive_contract: Contract, block_number: BlockNumber | None = None
+) -> FixedPoint:
+    """See API for documentation."""
+    asset_id = encode_asset_id(AssetIdPrefix.WITHDRAWAL_SHARE, 0)
+    total_supply_withdrawal_shares = smart_contract_read(
+        hyperdrive_contract,
+        "balanceOf",
+        asset_id,
+        hyperdrive_contract.address,
+        block_number,
+    )["value"]
+    return FixedPoint(scaled_value=int(total_supply_withdrawal_shares))
 
 
 def _get_variable_rate(yield_contract: Contract, block_number: BlockNumber | None = None) -> FixedPoint:

--- a/lib/ethpy/ethpy/hyperdrive/api/_mock_contract.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/_mock_contract.py
@@ -50,9 +50,9 @@ def _construct_pool_info(contract_pool_info: dict[str, Any]) -> PoolInfo:
     return PoolInfo(**contract_pool_info)
 
 
-def _calc_checkpoint_id(pool_state: PoolState, block_timestamp: Timestamp) -> Timestamp:
+def _calc_checkpoint_id(checkpoint_duration: int, block_timestamp: Timestamp) -> Timestamp:
     """See API for documentation."""
-    latest_checkpoint_timestamp = block_timestamp - (block_timestamp % pool_state.pool_config.checkpoint_duration)
+    latest_checkpoint_timestamp = block_timestamp - (block_timestamp % checkpoint_duration)
     return cast(Timestamp, latest_checkpoint_timestamp)
 
 

--- a/lib/ethpy/ethpy/hyperdrive/api/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/api.py
@@ -7,49 +7,33 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from ethpy import build_eth_config
-from ethpy.base import initialize_web3_with_http_provider, load_all_abis, smart_contract_read
+from ethpy.base import (initialize_web3_with_http_provider, load_all_abis,
+                        smart_contract_read)
 from ethpy.hyperdrive import AssetIdPrefix, encode_asset_id
-from ethpy.hyperdrive.addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
+from ethpy.hyperdrive.addresses import (HyperdriveAddresses,
+                                        fetch_hyperdrive_address_from_uri)
 from ethpy.hyperdrive.transactions import (
-    convert_hyperdrive_checkpoint_types,
-    convert_hyperdrive_pool_config_types,
-    convert_hyperdrive_pool_info_types,
-    get_hyperdrive_checkpoint,
-    get_hyperdrive_pool_config,
-    get_hyperdrive_pool_info,
-)
+    convert_hyperdrive_checkpoint_types, convert_hyperdrive_pool_config_types,
+    convert_hyperdrive_pool_info_types, get_hyperdrive_checkpoint,
+    get_hyperdrive_pool_config, get_hyperdrive_pool_info)
 from fixedpointmath import FixedPoint
 from web3.types import BlockData, BlockIdentifier, Timestamp
 
 from ._block_getters import _get_block, _get_block_number, _get_block_time
-from ._contract_calls import (
-    _async_add_liquidity,
-    _async_close_long,
-    _async_close_short,
-    _async_open_long,
-    _async_open_short,
-    _async_redeem_withdraw_shares,
-    _async_remove_liquidity,
-    _get_eth_base_balances,
-    _get_variable_rate,
-    _get_vault_shares,
-)
-from ._mock_contract import (
-    _calc_bonds_given_shares_and_rate,
-    _calc_checkpoint_id,
-    _calc_effective_share_reserves,
-    _calc_fees_out_given_bonds_in,
-    _calc_fees_out_given_shares_in,
-    _calc_fixed_rate,
-    _calc_in_for_out,
-    _calc_long_amount,
-    _calc_max_long,
-    _calc_max_short,
-    _calc_out_for_in,
-    _calc_position_duration_in_years,
-    _calc_short_deposit,
-    _calc_spot_price,
-)
+from ._contract_calls import (_async_add_liquidity, _async_close_long,
+                              _async_close_short, _async_open_long,
+                              _async_open_short, _async_redeem_withdraw_shares,
+                              _async_remove_liquidity, _get_eth_base_balances,
+                              _get_variable_rate, _get_vault_shares)
+from ._mock_contract import (_calc_bonds_given_shares_and_rate,
+                             _calc_checkpoint_id,
+                             _calc_effective_share_reserves,
+                             _calc_fees_out_given_bonds_in,
+                             _calc_fees_out_given_shares_in, _calc_fixed_rate,
+                             _calc_in_for_out, _calc_long_amount,
+                             _calc_max_long, _calc_max_short, _calc_out_for_in,
+                             _calc_position_duration_in_years,
+                             _calc_short_deposit, _calc_spot_price)
 
 # We expect to have many instance attributes & public methods since this is a large API.
 # pylint: disable=too-many-instance-attributes
@@ -146,9 +130,9 @@ class HyperdriveInterface:
 
     def get_current_block(self) -> BlockData:
         """Return the current block."""
-        return self.block("latest")
+        return self.get_block("latest")
 
-    def block(self, block_identifier: BlockIdentifier) -> BlockData:
+    def get_block(self, block_identifier: BlockIdentifier) -> BlockData:
         """Return the block for the provided identifier.
 
         Delegates to eth_getBlockByNumber if block_identifier is an integer or
@@ -211,7 +195,7 @@ class HyperdriveInterface:
         """
         if block is None:
             block_identifier = cast(BlockIdentifier, "latest")
-            block = self.block(block_identifier)
+            block = self.get_block(block_identifier)
         block_number = self.get_block_number(block)
         contract_pool_config = get_hyperdrive_pool_config(self.hyperdrive_contract)
         contract_pool_info = get_hyperdrive_pool_info(self.hyperdrive_contract, block_number)

--- a/lib/ethpy/ethpy/hyperdrive/api/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/api.py
@@ -7,48 +7,32 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from ethpy import build_eth_config
-from ethpy.base import initialize_web3_with_http_provider, load_all_abis, smart_contract_read
+from ethpy.base import (initialize_web3_with_http_provider, load_all_abis,
+                        smart_contract_read)
 from ethpy.hyperdrive import AssetIdPrefix, encode_asset_id
-from ethpy.hyperdrive.addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
+from ethpy.hyperdrive.addresses import (HyperdriveAddresses,
+                                        fetch_hyperdrive_address_from_uri)
 from ethpy.hyperdrive.transactions import (
-    convert_hyperdrive_checkpoint_types,
-    convert_hyperdrive_pool_config_types,
-    convert_hyperdrive_pool_info_types,
-    get_hyperdrive_checkpoint,
-    get_hyperdrive_pool_config,
-    get_hyperdrive_pool_info,
-)
+    convert_hyperdrive_checkpoint_types, convert_hyperdrive_pool_config_types,
+    convert_hyperdrive_pool_info_types, get_hyperdrive_checkpoint,
+    get_hyperdrive_pool_config, get_hyperdrive_pool_info)
 from web3.types import BlockData, BlockIdentifier, Timestamp
 
 from ._block_getters import _get_block, _get_block_number, _get_block_time
-from ._contract_calls import (
-    _async_add_liquidity,
-    _async_close_long,
-    _async_close_short,
-    _async_open_long,
-    _async_open_short,
-    _async_redeem_withdraw_shares,
-    _async_remove_liquidity,
-    _get_eth_base_balances,
-    _get_variable_rate,
-    _get_vault_shares,
-)
-from ._mock_contract import (
-    _calc_bonds_given_shares_and_rate,
-    _calc_checkpoint_id,
-    _calc_effective_share_reserves,
-    _calc_fees_out_given_bonds_in,
-    _calc_fees_out_given_shares_in,
-    _calc_fixed_rate,
-    _calc_in_for_out,
-    _calc_long_amount,
-    _calc_max_long,
-    _calc_max_short,
-    _calc_out_for_in,
-    _calc_position_duration_in_years,
-    _calc_short_deposit,
-    _calc_spot_price,
-)
+from ._contract_calls import (_async_add_liquidity, _async_close_long,
+                              _async_close_short, _async_open_long,
+                              _async_open_short, _async_redeem_withdraw_shares,
+                              _async_remove_liquidity, _get_eth_base_balances,
+                              _get_variable_rate, _get_vault_shares)
+from ._mock_contract import (_calc_bonds_given_shares_and_rate,
+                             _calc_checkpoint_id,
+                             _calc_effective_share_reserves,
+                             _calc_fees_out_given_bonds_in,
+                             _calc_fees_out_given_shares_in, _calc_fixed_rate,
+                             _calc_in_for_out, _calc_long_amount,
+                             _calc_max_long, _calc_max_short, _calc_out_for_in,
+                             _calc_position_duration_in_years,
+                             _calc_short_deposit, _calc_spot_price)
 
 # We expect to have many instance attributes & public methods since this is a large API.
 # pylint: disable=too-many-instance-attributes
@@ -148,15 +132,14 @@ class HyperdriveInterface:
         self.last_state_block_number = copy.copy(self._current_pool_state.block_number)
 
     @property
-    def current_block(self) -> BlockData:
-        """The current block."""
-        return self.block("latest")
-
-    @property
     def current_pool_state(self) -> PoolState:
         """The current state of the pool."""
         self._ensure_current_state()
         return self._current_pool_state
+
+    def get_current_block(self) -> BlockData:
+        """Return the current block."""
+        return self.block("latest")
 
     def block(self, block_identifier: BlockIdentifier) -> BlockData:
         """Return the block for the provided identifier.
@@ -205,7 +188,7 @@ class HyperdriveInterface:
 
     def _ensure_current_state(self) -> None:
         """Update the cached pool info and latest checkpoint if needed."""
-        current_block = self.current_block
+        current_block = self.get_current_block()
         if self.block_number(current_block) > self.last_state_block_number:
             self._current_pool_state = self.get_hyperdrive_state(current_block)
             self.last_state_block_number = copy.copy(self._current_pool_state.block_number)

--- a/lib/ethpy/ethpy/hyperdrive/api/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/api.py
@@ -7,33 +7,49 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from ethpy import build_eth_config
-from ethpy.base import (initialize_web3_with_http_provider, load_all_abis,
-                        smart_contract_read)
-from ethpy.hyperdrive.addresses import (HyperdriveAddresses,
-                                        fetch_hyperdrive_address_from_uri)
+from ethpy.base import initialize_web3_with_http_provider, load_all_abis, smart_contract_read
+from ethpy.hyperdrive.addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
 from ethpy.hyperdrive.transactions import (
-    convert_hyperdrive_checkpoint_types, convert_hyperdrive_pool_config_types,
-    convert_hyperdrive_pool_info_types, get_hyperdrive_checkpoint,
-    get_hyperdrive_pool_config, get_hyperdrive_pool_info)
+    convert_hyperdrive_checkpoint_types,
+    convert_hyperdrive_pool_config_types,
+    convert_hyperdrive_pool_info_types,
+    get_hyperdrive_checkpoint,
+    get_hyperdrive_pool_config,
+    get_hyperdrive_pool_info,
+)
 from fixedpointmath import FixedPoint
 from web3.types import BlockData, BlockIdentifier, Timestamp
 
 from ._block_getters import _get_block, _get_block_number, _get_block_time
-from ._contract_calls import (_async_add_liquidity, _async_close_long,
-                              _async_close_short, _async_open_long,
-                              _async_open_short, _async_redeem_withdraw_shares,
-                              _async_remove_liquidity, _get_eth_base_balances,
-                              _get_total_supply_withdrawal_shares,
-                              _get_variable_rate, _get_vault_shares)
-from ._mock_contract import (_calc_bonds_given_shares_and_rate,
-                             _calc_checkpoint_id,
-                             _calc_effective_share_reserves,
-                             _calc_fees_out_given_bonds_in,
-                             _calc_fees_out_given_shares_in, _calc_fixed_rate,
-                             _calc_in_for_out, _calc_long_amount,
-                             _calc_max_long, _calc_max_short, _calc_out_for_in,
-                             _calc_position_duration_in_years,
-                             _calc_short_deposit, _calc_spot_price)
+from ._contract_calls import (
+    _async_add_liquidity,
+    _async_close_long,
+    _async_close_short,
+    _async_open_long,
+    _async_open_short,
+    _async_redeem_withdraw_shares,
+    _async_remove_liquidity,
+    _get_eth_base_balances,
+    _get_total_supply_withdrawal_shares,
+    _get_variable_rate,
+    _get_vault_shares,
+)
+from ._mock_contract import (
+    _calc_bonds_given_shares_and_rate,
+    _calc_checkpoint_id,
+    _calc_effective_share_reserves,
+    _calc_fees_out_given_bonds_in,
+    _calc_fees_out_given_shares_in,
+    _calc_fixed_rate,
+    _calc_in_for_out,
+    _calc_long_amount,
+    _calc_max_long,
+    _calc_max_short,
+    _calc_out_for_in,
+    _calc_position_duration_in_years,
+    _calc_short_deposit,
+    _calc_spot_price,
+)
 
 # We expect to have many instance attributes & public methods since this is a large API.
 # pylint: disable=too-many-instance-attributes
@@ -228,7 +244,7 @@ class HyperdriveInterface:
         ---------
         block_number : BlockNumber, optional
             The number for any minted block.
-            Defaults to the current block number
+            Defaults to the current block number.
 
         Returns
         -------
@@ -246,7 +262,7 @@ class HyperdriveInterface:
         ---------
         block_number : BlockNumber, optional
             The number for any minted block.
-            Defaults to the current block number
+            Defaults to the current block number.
 
         Returns
         -------
@@ -264,7 +280,7 @@ class HyperdriveInterface:
         ---------
         block_number : BlockNumber, optional
             The number for any minted block.
-            Defaults to the current block number
+            Defaults to the current block number.
 
         Returns
         -------
@@ -526,7 +542,7 @@ class HyperdriveInterface:
         ---------
         checkpoint_duration : int, optional
             The time, in seconds, between checkpoints.
-            Defaults to the current pool's checkpoint duration
+            Defaults to the current pool's checkpoint duration.
         block_timestamp : Timestamp, optional
             A timestamp for any block. Use the latest block to get the current checkpoint id,
             or a specific timestamp of a transaction's block if getting the checkpoint id for that transaction.

--- a/lib/ethpy/ethpy/hyperdrive/api/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/api.py
@@ -7,33 +7,49 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from ethpy import build_eth_config
-from ethpy.base import (initialize_web3_with_http_provider, load_all_abis,
-                        smart_contract_read)
+from ethpy.base import initialize_web3_with_http_provider, load_all_abis, smart_contract_read
 from ethpy.hyperdrive import AssetIdPrefix, encode_asset_id
-from ethpy.hyperdrive.addresses import (HyperdriveAddresses,
-                                        fetch_hyperdrive_address_from_uri)
+from ethpy.hyperdrive.addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
 from ethpy.hyperdrive.transactions import (
-    convert_hyperdrive_checkpoint_types, convert_hyperdrive_pool_config_types,
-    convert_hyperdrive_pool_info_types, get_hyperdrive_checkpoint,
-    get_hyperdrive_pool_config, get_hyperdrive_pool_info)
+    convert_hyperdrive_checkpoint_types,
+    convert_hyperdrive_pool_config_types,
+    convert_hyperdrive_pool_info_types,
+    get_hyperdrive_checkpoint,
+    get_hyperdrive_pool_config,
+    get_hyperdrive_pool_info,
+)
 from fixedpointmath import FixedPoint
 from web3.types import BlockData, BlockIdentifier, Timestamp
 
 from ._block_getters import _get_block, _get_block_number, _get_block_time
-from ._contract_calls import (_async_add_liquidity, _async_close_long,
-                              _async_close_short, _async_open_long,
-                              _async_open_short, _async_redeem_withdraw_shares,
-                              _async_remove_liquidity, _get_eth_base_balances,
-                              _get_variable_rate, _get_vault_shares)
-from ._mock_contract import (_calc_bonds_given_shares_and_rate,
-                             _calc_checkpoint_id,
-                             _calc_effective_share_reserves,
-                             _calc_fees_out_given_bonds_in,
-                             _calc_fees_out_given_shares_in, _calc_fixed_rate,
-                             _calc_in_for_out, _calc_long_amount,
-                             _calc_max_long, _calc_max_short, _calc_out_for_in,
-                             _calc_position_duration_in_years,
-                             _calc_short_deposit, _calc_spot_price)
+from ._contract_calls import (
+    _async_add_liquidity,
+    _async_close_long,
+    _async_close_short,
+    _async_open_long,
+    _async_open_short,
+    _async_redeem_withdraw_shares,
+    _async_remove_liquidity,
+    _get_eth_base_balances,
+    _get_variable_rate,
+    _get_vault_shares,
+)
+from ._mock_contract import (
+    _calc_bonds_given_shares_and_rate,
+    _calc_checkpoint_id,
+    _calc_effective_share_reserves,
+    _calc_fees_out_given_bonds_in,
+    _calc_fees_out_given_shares_in,
+    _calc_fixed_rate,
+    _calc_in_for_out,
+    _calc_long_amount,
+    _calc_max_long,
+    _calc_max_short,
+    _calc_out_for_in,
+    _calc_position_duration_in_years,
+    _calc_short_deposit,
+    _calc_spot_price,
+)
 
 # We expect to have many instance attributes & public methods since this is a large API.
 # pylint: disable=too-many-instance-attributes

--- a/lib/ethpy/ethpy/hyperdrive/api/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/api.py
@@ -7,49 +7,33 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from ethpy import build_eth_config
-from ethpy.base import initialize_web3_with_http_provider, load_all_abis, smart_contract_read
-from ethpy.hyperdrive import AssetIdPrefix, encode_asset_id
-from ethpy.hyperdrive.addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
+from ethpy.base import (initialize_web3_with_http_provider, load_all_abis,
+                        smart_contract_read)
+from ethpy.hyperdrive.addresses import (HyperdriveAddresses,
+                                        fetch_hyperdrive_address_from_uri)
 from ethpy.hyperdrive.transactions import (
-    convert_hyperdrive_checkpoint_types,
-    convert_hyperdrive_pool_config_types,
-    convert_hyperdrive_pool_info_types,
-    get_hyperdrive_checkpoint,
-    get_hyperdrive_pool_config,
-    get_hyperdrive_pool_info,
-)
+    convert_hyperdrive_checkpoint_types, convert_hyperdrive_pool_config_types,
+    convert_hyperdrive_pool_info_types, get_hyperdrive_checkpoint,
+    get_hyperdrive_pool_config, get_hyperdrive_pool_info)
 from fixedpointmath import FixedPoint
 from web3.types import BlockData, BlockIdentifier, Timestamp
 
 from ._block_getters import _get_block, _get_block_number, _get_block_time
-from ._contract_calls import (
-    _async_add_liquidity,
-    _async_close_long,
-    _async_close_short,
-    _async_open_long,
-    _async_open_short,
-    _async_redeem_withdraw_shares,
-    _async_remove_liquidity,
-    _get_eth_base_balances,
-    _get_variable_rate,
-    _get_vault_shares,
-)
-from ._mock_contract import (
-    _calc_bonds_given_shares_and_rate,
-    _calc_checkpoint_id,
-    _calc_effective_share_reserves,
-    _calc_fees_out_given_bonds_in,
-    _calc_fees_out_given_shares_in,
-    _calc_fixed_rate,
-    _calc_in_for_out,
-    _calc_long_amount,
-    _calc_max_long,
-    _calc_max_short,
-    _calc_out_for_in,
-    _calc_position_duration_in_years,
-    _calc_short_deposit,
-    _calc_spot_price,
-)
+from ._contract_calls import (_async_add_liquidity, _async_close_long,
+                              _async_close_short, _async_open_long,
+                              _async_open_short, _async_redeem_withdraw_shares,
+                              _async_remove_liquidity, _get_eth_base_balances,
+                              _get_total_supply_withdrawal_shares,
+                              _get_variable_rate, _get_vault_shares)
+from ._mock_contract import (_calc_bonds_given_shares_and_rate,
+                             _calc_checkpoint_id,
+                             _calc_effective_share_reserves,
+                             _calc_fees_out_given_bonds_in,
+                             _calc_fees_out_given_shares_in, _calc_fixed_rate,
+                             _calc_in_for_out, _calc_long_amount,
+                             _calc_max_long, _calc_max_short, _calc_out_for_in,
+                             _calc_position_duration_in_years,
+                             _calc_short_deposit, _calc_spot_price)
 
 # We expect to have many instance attributes & public methods since this is a large API.
 # pylint: disable=too-many-instance-attributes
@@ -221,16 +205,7 @@ class HyperdriveInterface:
         )
         variable_rate = _get_variable_rate(self.yield_contract, block_number)
         vault_shares = _get_vault_shares(self.yield_contract, self.hyperdrive_contract, block_number)
-        asset_id = encode_asset_id(AssetIdPrefix.WITHDRAWAL_SHARE, 0)
-        total_supply_withdrawal_shares = FixedPoint(
-            smart_contract_read(
-                self.hyperdrive_contract,
-                "balanceOf",
-                asset_id,
-                self.hyperdrive_contract.address,
-                block_number,
-            )["value"]
-        )
+        total_supply_withdrawal_shares = _get_total_supply_withdrawal_shares(self.hyperdrive_contract, block_number)
         return PoolState(
             block,
             contract_pool_config,

--- a/lib/ethpy/ethpy/hyperdrive/api/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/api_test.py
@@ -56,7 +56,7 @@ class TestHyperdriveInterface:
         hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
         eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
         hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
-        checkpoint_id = hyperdrive.calc_checkpoint_id(hyperdrive.current_pool_state.block_time)
+        checkpoint_id = hyperdrive.calc_checkpoint_id(block_timestamp=hyperdrive.current_pool_state.block_time)
         checkpoint = smart_contract_read(hyperdrive.hyperdrive_contract, "getCheckpoint", checkpoint_id)
         assert checkpoint == hyperdrive.current_pool_state.contract_checkpoint
 


### PR DESCRIPTION
A PoolState object can now be constructed one of two ways.

----------------

using the hyperdrive interface itself to grab the actual state:
```python
from eth_typing import BlockNumber
from ethpy.hyperdrive.api import HyperdriveInterface

hyperdrive = HyperdriveInterface()

# get pool state for some arbitrary block number
pool_state = hyperdrive.get_hyperdrive_state(hyperdrive.get_block(BlockNumber(100)))

# get the current pool state
# this is cached, and also guarantees that all class attributes correspond to the same block
current_pool_state = hyperdrive.current_pool_state
```

----------------

or you can build it from scratch using data from any block or your own values:
```python
from ethpy.hyperdrive.transactions import (
    get_hyperdrive_checkpoint,
    get_hyperdrive_pool_config,
    get_hyperdrive_pool_info
)
from ethpy.hyperdrive.api import HyperdriveInterface, PoolState

hyperdrive = HyperdriveInterface()

# Could use any block as a reference
block = hyperdrive.get_current_block()
block_number = hyperdrive.get_block_number(block)

# we will use actual pool values, but these dictionaries can have any value as long as the keys & types are correct
contract_pool_config = get_hyperdrive_pool_config(hyperdrive.hyperdrive_contract)
contract_pool_info = get_hyperdrive_pool_info(hyperdrive.hyperdrive_contract, block_number)
contract_checkpoint = get_hyperdrive_checkpoint(
    hyperdrive.hyperdrive_contract,
    hyperdrive.calc_checkpoint_id(contract_pool_config["checkpointDuration"], hyperdrive.get_block_timestamp(block)),
)
variable_rate = hyperdrive.get_variable_rate(block_number)
vault_shares = hyperdrive.get_vault_shares(block_number)
total_supply_withdrawal_shares = hyperdrive.get_total_supply_withdrawal_shares(block_number)

# could change any of these when constructing the object
pool_state = PoolState(
            block,
            contract_pool_config,
            contract_pool_info,
            contract_checkpoint,
            variable_rate,
            vault_shares,
            total_supply_withdrawal_shares,
        )
```

----------------

Once you have the pool_state, you can call any of the underlying hyperdrive helper functions, e.g.

```python
bonds = hyperdrive.calc_bonds_given_shares_and_rate(
    target_rate=FixedPoint("0.05"),
    target_shares=FixedPoint(1*10**6),
    pool_state=pool_state,
)
```

----------------

I also made some minor updates:
- function & variable names are changed to make it more clear that they're doing RPC calls under the hood
- added some API helper functions to expose more private calculation & getter methods
- moved manual repeated code for calculating the total_supply_withdrawal_shares into a private calculation method